### PR TITLE
Resolve harness session stores correctly on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,18 @@ jobs:
       - run: cargo clippy --lib --no-default-features
       - run: cargo test --workspace --all-features
 
+  windows:
+    name: Lint and test (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets --all-features
+      - run: cargo test --workspace --all-features
+
   wasm:
     name: wasm32 build
     runs-on: ubuntu-latest

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -602,14 +602,25 @@ fn handoff(
     args: &[String],
     workdir: Option<&std::path::Path>,
 ) -> Result<ExitCode, String> {
-    let mut cmd = std::process::Command::new(bin);
-    cmd.args(args);
-    if let Some(dir) = workdir {
-        cmd.current_dir(dir);
-    }
-    let status = cmd
-        .status()
-        .map_err(|e| format!("failed to launch `{bin}`: {e} (is it on PATH?)"))?;
+    let spawn = |program: &str| {
+        let mut cmd = std::process::Command::new(program);
+        cmd.args(args);
+        if let Some(dir) = workdir {
+            cmd.current_dir(dir);
+        }
+        cmd.status()
+    };
+    let status = match spawn(bin) {
+        Ok(status) => status,
+        // npm-installed harnesses are `.cmd` shims on Windows, which
+        // CreateProcess won't resolve from the bare name; the explicit
+        // extension makes std route the launch through cmd.exe.
+        Err(e) if cfg!(windows) && e.kind() == std::io::ErrorKind::NotFound => {
+            spawn(&format!("{bin}.cmd"))
+                .map_err(|_| format!("failed to launch `{bin}`: {e} (is it on PATH?)"))?
+        }
+        Err(e) => return Err(format!("failed to launch `{bin}`: {e} (is it on PATH?)")),
+    };
     Ok(match status.code() {
         // `ExitCode` is u8-wide; a child code outside 0..=255 still reports
         // failure, just not the exact value.

--- a/src/harness/amp.rs
+++ b/src/harness/amp.rs
@@ -425,7 +425,7 @@ fn build_env(meta: &Meta) -> Option<Value> {
     if let Some(cwd) = meta.cwd.as_deref().filter(|c| !c.is_empty()) {
         let mut tree = Map::new();
         tree.insert("uri".into(), json!(path_to_file_uri(cwd)));
-        let name = cwd.rsplit('/').next().unwrap_or(cwd);
+        let name = cwd.rsplit(['/', '\\']).next().unwrap_or(cwd);
         tree.insert("displayName".into(), json!(name));
         if let Some(branch) = meta.git_branch.as_deref().filter(|b| !b.is_empty()) {
             tree.insert(
@@ -909,12 +909,34 @@ fn file_uri_to_path(uri: &str) -> Option<String> {
             }
         }
     }
-    Some(String::from_utf8_lossy(&out).into_owned())
+    let decoded = String::from_utf8_lossy(&out).into_owned();
+    // A drive-letter path came from Windows (`file:///C%3A/Users/x` →
+    // `/C:/Users/x`): drop the URI's leading slash and restore backslashes.
+    let bytes = decoded.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0] == b'/'
+        && bytes[1].is_ascii_alphabetic()
+        && bytes[2] == b':'
+        && bytes.get(3).is_none_or(|b| *b == b'/')
+    {
+        return Some(decoded[1..].replace('/', "\\"));
+    }
+    Some(decoded)
 }
 
 /// `/a b` → `file:///a%20b`, percent-encoding everything outside the RFC 3986
-/// unreserved set (plus `/`).
+/// unreserved set (plus `/`). A Windows path is normalized into URI shape
+/// first (`C:\Users\x` → `file:///C%3A/Users/x`).
 fn path_to_file_uri(path: &str) -> String {
+    let bytes = path.as_bytes();
+    let windows = bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':';
+    let normalized;
+    let path = if windows {
+        normalized = format!("/{}", path.replace('\\', "/"));
+        normalized.as_str()
+    } else {
+        path
+    };
     let mut out = String::with_capacity(path.len() + 8);
     out.push_str("file://");
     for byte in path.bytes() {
@@ -967,14 +989,19 @@ impl AmpStore {
             .filter(|v| !v.is_empty())
             .map(PathBuf::from)
             .or_else(|| {
-                std::env::var_os("XDG_DATA_HOME")
-                    .filter(|v| !v.is_empty())
-                    .map(|xdg| PathBuf::from(xdg).join("amp").join("threads"))
+                // amp's own platform switch consults XDG_DATA_HOME only off
+                // Windows; there the data dir is always `<home>\.local\share\amp`.
+                if cfg!(windows) {
+                    None
+                } else {
+                    std::env::var_os("XDG_DATA_HOME")
+                        .filter(|v| !v.is_empty())
+                        .map(|xdg| PathBuf::from(xdg).join("amp").join("threads"))
+                }
             })
             .or_else(|| {
-                std::env::var_os("HOME").map(|home| {
-                    PathBuf::from(home)
-                        .join(".local")
+                super::home_dir().map(|home| {
+                    home.join(".local")
                         .join("share")
                         .join("amp")
                         .join("threads")

--- a/src/harness/antigravity.rs
+++ b/src/harness/antigravity.rs
@@ -1745,9 +1745,7 @@ impl AntigravityStore {
     /// The default data root, `~/.gemini/antigravity-cli`.
     #[must_use]
     pub fn default_root() -> Option<Self> {
-        std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .map(|home| Self::new(home.join(".gemini").join("antigravity-cli")))
+        super::home_dir().map(|home| Self::new(home.join(".gemini").join("antigravity-cli")))
     }
 
     #[cfg(feature = "opencode")]

--- a/src/harness/claude_code.rs
+++ b/src/harness/claude_code.rs
@@ -263,10 +263,15 @@ impl ClaudeStore {
         Self { root: root.into() }
     }
 
-    /// The default projects root, `~/.claude/projects`.
+    /// The default projects root: `$CLAUDE_CONFIG_DIR/projects` when set
+    /// (every `~/.claude` path moves under that directory), else
+    /// `~/.claude/projects`.
     #[must_use]
     pub fn default_root() -> Option<Self> {
-        dirs_home().map(|h| Self::new(h.join(".claude").join("projects")))
+        std::env::var_os("CLAUDE_CONFIG_DIR")
+            .filter(|v| !v.is_empty())
+            .map(|dir| Self::new(PathBuf::from(dir).join("projects")))
+            .or_else(|| dirs_home().map(|h| Self::new(h.join(".claude").join("projects"))))
     }
 
     fn collect_jsonl(dir: &Path, out: &mut Vec<PathBuf>) {
@@ -755,10 +760,18 @@ fn meta_from_text(text: &str) -> Meta {
     meta_from_records(&records)
 }
 
-/// Claude's project-dir encoding: every `/` and `.` becomes `-`.
+/// Claude's project-dir encoding: every `/` and `.` becomes `-`. Windows
+/// cwds encode the same way with `\` and the drive `:` also mapped
+/// (`C:\Users\x` → `C--Users-x`).
 fn encode_project_dir(path: &str) -> String {
     path.chars()
-        .map(|c| if c == '/' || c == '.' { '-' } else { c })
+        .map(|c| {
+            if matches!(c, '/' | '.' | '\\' | ':') {
+                '-'
+            } else {
+                c
+            }
+        })
         .collect()
 }
 
@@ -778,7 +791,7 @@ fn file_fingerprint(path: &Path) -> String {
 }
 
 fn dirs_home() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(PathBuf::from)
+    super::home_dir()
 }
 
 // Surface the canonical-name guard as a typed error for callers that care.

--- a/src/harness/codex.rs
+++ b/src/harness/codex.rs
@@ -666,10 +666,14 @@ impl CodexStore {
         }
     }
 
-    /// The default sessions root, `~/.codex/sessions`.
+    /// The default sessions root: `$CODEX_HOME/sessions` when set (Codex
+    /// honors that override before its home lookup), else `~/.codex/sessions`.
     #[must_use]
     pub fn default_root() -> Option<Self> {
-        home().map(|h| Self::new(h.join(".codex").join("sessions")))
+        std::env::var_os("CODEX_HOME")
+            .filter(|v| !v.is_empty())
+            .map(|codex_home| Self::new(PathBuf::from(codex_home).join("sessions")))
+            .or_else(|| home().map(|h| Self::new(h.join(".codex").join("sessions"))))
     }
 }
 
@@ -1299,5 +1303,5 @@ fn file_fingerprint(path: &Path) -> String {
 }
 
 fn home() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(PathBuf::from)
+    super::home_dir()
 }

--- a/src/harness/cursor.rs
+++ b/src/harness/cursor.rs
@@ -1816,7 +1816,7 @@ fn file_fingerprint(path: &Path) -> String {
 }
 
 fn dirs_home() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(PathBuf::from)
+    super::home_dir()
 }
 
 // -- hashes and hex ------------------------------------------------------

--- a/src/harness/grok.rs
+++ b/src/harness/grok.rs
@@ -1237,10 +1237,7 @@ impl GrokStore {
         std::env::var_os("GROK_HOME")
             .filter(|v| !v.is_empty())
             .map(|home| Self::new(PathBuf::from(home).join("sessions")))
-            .or_else(|| {
-                std::env::var_os("HOME")
-                    .map(|h| Self::new(PathBuf::from(h).join(".grok").join("sessions")))
-            })
+            .or_else(|| super::home_dir().map(|h| Self::new(h.join(".grok").join("sessions"))))
     }
 }
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -16,3 +16,17 @@ pub mod opencode;
 pub mod pi;
 
 pub(crate) mod jsonl;
+
+/// The user's home directory, resolved the way the harness CLIs themselves
+/// resolve it: `$HOME` on Unix; on Windows `%USERPROFILE%` first (Node's
+/// `os.homedir()` and Rust's home crates ignore `$HOME` there), with `$HOME`
+/// as a fallback for MSYS/Cygwin-style shells.
+pub(crate) fn home_dir() -> Option<std::path::PathBuf> {
+    #[cfg(windows)]
+    let home = std::env::var_os("USERPROFILE")
+        .filter(|v| !v.is_empty())
+        .or_else(|| std::env::var_os("HOME"));
+    #[cfg(not(windows))]
+    let home = std::env::var_os("HOME");
+    home.filter(|v| !v.is_empty()).map(std::path::PathBuf::from)
+}

--- a/src/harness/opencode.rs
+++ b/src/harness/opencode.rs
@@ -797,9 +797,8 @@ mod store {
                         .map(|xdg| PathBuf::from(xdg).join("opencode").join("opencode.db"))
                 })
                 .or_else(|| {
-                    std::env::var_os("HOME").map(|home| {
-                        PathBuf::from(home)
-                            .join(".local")
+                    crate::harness::home_dir().map(|home| {
+                        home.join(".local")
                             .join("share")
                             .join("opencode")
                             .join("opencode.db")

--- a/src/harness/pi.rs
+++ b/src/harness/pi.rs
@@ -618,7 +618,7 @@ pub(crate) fn resolve_sessions_dir(config_dir: &str, env_prefix: &str) -> Option
         if raw.is_empty() {
             None
         } else if let Some(rest) = raw.strip_prefix('~') {
-            home().map(|h| h.join(rest.trim_start_matches('/')))
+            home().map(|h| h.join(rest.trim_start_matches(['/', '\\'])))
         } else {
             Some(PathBuf::from(raw))
         }
@@ -1124,5 +1124,5 @@ fn file_fingerprints(refs: &[PathBuf]) -> HashMap<String, String> {
 }
 
 fn home() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(PathBuf::from)
+    super::home_dir()
 }

--- a/tests/amp.rs
+++ b/tests/amp.rs
@@ -523,6 +523,18 @@ fn codec_fixpoint_through_common_loses_nothing() {
     assert_eq!(common, back);
 }
 
+/// A Windows cwd survives the trip through Amp's reconstructed `file://`
+/// env URI: `C:\…` normalizes to `file:///C%3A/…` and decodes back.
+#[test]
+fn windows_cwd_round_trips_through_the_env_uri() {
+    let mut common = sample_common();
+    common.meta.cwd = Some(r"C:\Users\dev\proj x".into());
+
+    let native = amp::Amp::from_common(&common).unwrap();
+    let back = amp::Amp::to_common(&native).unwrap();
+    assert_eq!(back.meta.cwd.as_deref(), Some(r"C:\Users\dev\proj x"));
+}
+
 /// A foreign session id (Claude uuid) becomes a deterministic, valid
 /// `T-…` thread id, and the store names the file by it — `amp threads
 /// continue` rejects anything else before even looking it up.

--- a/tests/claude_code.rs
+++ b/tests/claude_code.rs
@@ -92,6 +92,22 @@ fn store_round_trip_is_lossless_on_disk() {
 }
 
 #[test]
+fn windows_cwd_encodes_the_project_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = claude_code::ClaudeStore::new(dir.path());
+
+    let src = dir.path().join("orig.jsonl");
+    let jsonl = sample_jsonl().replace("/work/repo", r"C:\\Users\\dev\\repo");
+    std::fs::write(&src, jsonl).unwrap();
+
+    // `C:\Users\dev\repo` lands in `C--Users-dev-repo`, Claude's own
+    // Windows encoding (`\` and `:` map to `-` like `/` and `.`).
+    let saved = store.save(&store.load(&src).unwrap()).unwrap();
+    let project = saved.reference.parent().unwrap().file_name().unwrap();
+    assert_eq!(project.to_str(), Some("C--Users-dev-repo"));
+}
+
+#[test]
 fn discover_extracts_session_metadata() {
     let dir = tempfile::tempdir().unwrap();
     let project = dir.path().join("-work-repo");

--- a/tests/codex.rs
+++ b/tests/codex.rs
@@ -145,8 +145,14 @@ fn store_round_trip_is_lossless_on_disk() {
     let reloaded = store.load(&saved.reference).unwrap();
 
     assert_eq!(loaded.body, reloaded.body);
-    // Landed under YYYY/MM/DD with a rollout-<ts>-<id> name.
-    assert!(saved.reference.to_string_lossy().contains("/2026/01/02/"));
+    // Landed under YYYY/MM/DD with a rollout-<ts>-<id> name. Compare path
+    // components, not the string — separators differ on Windows.
+    let components: Vec<_> = saved
+        .reference
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    assert!(components.windows(3).any(|w| w == ["2026", "01", "02"]));
     assert!(saved.reference.to_string_lossy().contains("rollout-"));
     assert!(saved.reference.to_string_lossy().ends_with("sess-1.jsonl"));
 }


### PR DESCRIPTION
Every harness CLI resolves its data root from the platform home directory, which on Windows is `%USERPROFILE%` — Node's `os.homedir()`, Go's `os.UserHomeDir()`, and Rust's home crates all ignore `$HOME` there — so a shared `harness::home_dir()` now prefers `USERPROFILE` under `cfg(windows)` (with `$HOME` as an MSYS-style fallback), and amp skips `XDG_DATA_HOME` on Windows to mirror its own platform switch. Windows path content is handled wherever it appears in session data: Claude project dirs encode `\` and `:` to `-` (`C:\Users\x` → `C--Users-x`), amp `file://` URIs normalize and recover drive-letter cwds, amp display names split on either separator, and pi tilde expansion trims both separators. Store roots additionally honor the documented `CLAUDE_CONFIG_DIR` and `CODEX_HOME` overrides, and the CLI handoff retries npm `.cmd` shims that `CreateProcess` cannot resolve from a bare name. CI gains a `windows-latest` clippy+test job; each Windows location was verified against harness documentation or cross-platform source, and the change is corpus-checked against 882 real local sessions with byte-identical discover+read output vs `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)