### PR TITLE
Add Simple, an interchange pseudo-harness for unlisted agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ txcript maps each harness's native transcript format through a typed common mode
 
 ## Highlights
 
-- **10 harnesses, one model**: every format converts through `Transcript<Common>`, so adding a harness connects it to all the others.
+- **11 harnesses, one model**: every format converts through `Transcript<Common>`, so adding a harness connects it to all the others.
+- **A format for everyone else**: agents txcript has never heard of emit the documented [Simple](docs/formats/simple.md) interchange JSON — a file or a stream, handed to txcript directly — and their transcripts continue in any supported harness.
 - **Byte-lossless round-trips**: loading and saving a session in its own format reproduces it exactly.
 - **Continue anywhere**: `txcript continue <id> --with <harness>` rewrites a session into another harness's native format and launches it. The original is never modified.
 - **Search everything**: fuzzy/substring search across every session on the machine (fzf-style syntax, powered by [nucleo](https://github.com/helix-editor/nucleo)), as a library API, a one-shot CLI query, or an interactive picker.
@@ -67,10 +68,11 @@ flowchart LR
     common <--> cursordesktop["Cursor desktop"]
     common <--> grok["Grok CLI"]
     common <--> antigravity["Antigravity"]
+    simple["Simple (any agent)"] --> common
     amp["Amp"] --> common
 ```
 
-Discovery, listing, search, `view`, and native round-trips work for every harness. The `id` strings are what the CLI and WASM APIs take.
+Discovery, listing, search, `view`, and native round-trips work for every harness with a local store. The `id` strings are what the CLI and WASM APIs take.
 
 | Harness | id | Sessions on disk | Native format | Convert | Continue into | Doc |
 |---|---|---|---|:---:|:---:|---|
@@ -84,8 +86,11 @@ Discovery, listing, search, `view`, and native round-trips work for every harnes
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | JSON session dir | ⇄ | ✓ | [spec](docs/formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | thread JSON | → | — <sup>1</sup> | [spec](docs/formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [spec](docs/formats/antigravity.md) |
+| Simple | `simple` | — <sup>2</sup> | interchange JSON | → | — <sup>2</sup> | [spec](docs/formats/simple.md) |
 
 <sup>1</sup> Amp threads are server-side and the CLI has no import: sessions convert *from* Amp, but can't be continued into it.
+
+<sup>2</sup> Simple is txcript's own interchange format — the on-ramp for any agent not listed above. There is no app and no managed directory: a Simple session is a document (a file, or stdin) handed to `txcript continue` directly, and the continued conversation lives in the target harness from then on.
 
 ## Install
 
@@ -263,7 +268,7 @@ writeFileSync("session.jsonl", convert(input, "codex", "claude_code"));
 const common = JSON.parse(toCommon(input, "codex"));   // { meta, messages }
 const pi = fromCommon(JSON.stringify(common), "pi");
 
-harnesses(); // ["claude_code","codex","opencode","pi","campfire","cursor","cursor_desktop","grok","amp","antigravity"]
+harnesses(); // ["claude_code","codex","opencode","pi","campfire","cursor","cursor_desktop","grok","amp","antigravity","simple"]
 ```
 
 Text-in / text-out: `input` is the source harness's native session text and the result is the target's. Invalid harness names or unparseable input throw a JS `Error`.
@@ -277,6 +282,7 @@ Text-in / text-out: `input` is the source harness's native session text and the 
 | `grok` | JSON bundle of the session directory's files |
 | `amp` | `amp threads export` JSON |
 | `antigravity` | JSON dump of the conversation database, protobuf blobs hex-encoded |
+| `simple` | the [Simple](docs/formats/simple.md) interchange JSON document |
 
 To build the wasm from source instead:
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -50,7 +50,7 @@ mod mcp;
 mod view;
 
 const HARNESSES: &str = "harnesses: claude_code, codex, opencode, pi, campfire, cursor, cursor_desktop, grok, amp, \
-     antigravity";
+     antigravity, simple";
 
 #[derive(Parser)]
 #[command(
@@ -748,6 +748,7 @@ mod style {
             HarnessId::Grok => "\x1b[37m",          // white
             HarnessId::Amp => "\x1b[95m",           // bright magenta
             HarnessId::Antigravity => "\x1b[94m",   // bright blue
+            HarnessId::Simple => "\x1b[92m",        // bright green
         }
     }
 }

--- a/docs/formats/README.md
+++ b/docs/formats/README.md
@@ -48,3 +48,4 @@ than none.
 | [antigravity.md](antigravity.md) | Antigravity (Google) | `src/harness/antigravity.rs` |
 | [pi.md](pi.md) | pi | `src/harness/pi.rs` |
 | [campfire.md](campfire.md) | Campfire (embeds pi) | `src/harness/campfire.rs` |
+| [simple.md](simple.md) | Simple (txcript's own interchange format) | `src/harness/simple.rs` |

--- a/docs/formats/simple.md
+++ b/docs/formats/simple.md
@@ -1,0 +1,342 @@
+# Simple
+
+Simple is txcript's own interchange format: a single JSON document any agent
+can emit to make its transcripts portable into every harness txcript
+supports. It is the one format in this collection with no app behind it —
+there is nothing to resume natively, no storage schema to reverse-engineer.
+This document is not a description of the format; it *is* the format. The
+parser in `src/harness/simple.rs` and the integration tests are the
+authoritative mapping, per the convention of this collection.
+
+Simple is a forgiving projection of txcript's canonical model
+(`Transcript<Common>`): every field the canonical model carries has a slot
+here, and almost every slot is optional. The block shapes follow the
+Anthropic Messages API convention, which is also the canonical model's
+convention — an agent built on that API can emit its message array nearly
+verbatim.
+
+```
+{
+  "id": "...", "timestamp": "...",              session metadata,
+  "cwd": "...", "title": "...", "model": "...", all optional
+  "messages": [
+    {"role": "user",      "content": "..."},        string content, or
+    {"role": "assistant", "content": [ ... ]}       Anthropic-style blocks
+  ]
+}
+```
+
+The format is specified as fidelity levels. Every level is the same schema
+read further — nothing is enforced per level, any mix parses. An emitter
+reads until it has what it needs and stops.
+
+## On disk
+
+Nowhere, deliberately. A Simple session is a document you hand to txcript
+directly — there is no managed directory, no discovery, and nothing appears
+in `txcript list`. The document itself is the session: keep it wherever you
+like, or never materialize it at all and pipe it in.
+
+Handing it over is the entire import story:
+
+```sh
+txcript continue ./run.json --with claude_code    # a file
+my-agent --dump | txcript continue - --with claude_code    # stdin
+```
+
+txcript parses the document, rewrites it as a real session in the target
+harness's own store, and launches that harness on it. From that moment the
+conversation lives in the target harness; the source document is never
+modified.
+
+Simple is an interchange *input*: sessions are continued from Simple
+documents, not written into them, so `--with simple` is refused. (The codec
+itself is symmetric — the library and WASM APIs can render Simple text —
+but txcript manages no location to write such a document to.)
+
+## The format, level by level
+
+### L0 — barebones
+
+The minimum valid document: `messages`, each with `role` and `content` as a
+plain string.
+
+```json
+{
+  "messages": [
+    { "role": "user", "content": "fix the off-by-one in pagination" },
+    { "role": "assistant", "content": "Fixed - the loop bound was inclusive." }
+  ]
+}
+```
+
+`role` is `"user"` or `"assistant"` (matched case-insensitively). This is
+already enough to continue into any harness: txcript synthesizes the
+session id, timestamps, and per-harness bookkeeping.
+
+### L1 — tool use
+
+`content` becomes an array of blocks. Five block types are modeled:
+
+| Block | Fields | Notes |
+|---|---|---|
+| `text` | `text` | |
+| `thinking` | `text` | model reasoning; see L6 for provider tokens |
+| `tool_use` | `name`, `input`, `id`? | `input` is any JSON, default `null` |
+| `tool_result` | `content`, `tool_use_id`?, `is_error`? | `content` is a string or any JSON |
+| `image` | `source` | see L6 |
+
+```json
+{
+  "messages": [
+    { "role": "user", "content": "run the tests" },
+    { "role": "assistant", "content": [
+        { "type": "thinking", "text": "cargo test covers it." },
+        { "type": "tool_use", "name": "Bash", "input": { "command": "cargo test" } }
+    ] },
+    { "role": "user", "content": [
+        { "type": "tool_result", "content": "42 passed" }
+    ] },
+    { "role": "assistant", "content": "All green." }
+  ]
+}
+```
+
+Pairing: a `tool_use` without an `id` gets a deterministic synthetic one; a
+`tool_result` without a `tool_use_id` pairs with the oldest preceding
+unpaired `tool_use` (first-in-first-out, the Anthropic ordering convention).
+Supply explicit ids to pair out of order or to interleave concurrent calls.
+`tool_result` blocks ride on `user` messages, per the same convention.
+
+Tool names are free-form. Any name passes through losslessly; names in the
+Claude canonical convention (`Bash`, `Read`, `Write`, `Edit`, `MultiEdit`,
+with `file_path`/`old_string`/… argument keys) are recognized and render as
+typed, native tool calls in the target harness. A name starting with `/` is
+a user-invoked command (`{"name": "/release", "input": {"args": "patch"}}`),
+paired with whatever the command printed as its `tool_result`.
+
+Skills need no special representation: a model-invoked skill is a `tool_use`
+(e.g. name `Skill`) whose loaded instructions arrive as the paired
+`tool_result`; a user-invoked skill is a `/command`. Context the
+conversation depends on but that no tool call produced (injected memories,
+preloaded instructions) belongs inline in `user` content, exactly where the
+model saw it. Environment scaffolding the target harness regenerates on
+resume (directory listings, git status) is best omitted.
+
+### L2 — model name
+
+`model` at the top level names the session's primary model; `model` on an
+assistant message overrides it per turn when it varies.
+
+```json
+{
+  "model": "claude-opus-5",
+  "messages": [
+    { "role": "user", "content": "hi" },
+    { "role": "assistant", "content": "Hello.", "model": "claude-opus-5" }
+  ]
+}
+```
+
+### L3 — session metadata
+
+Top-level `timestamp` (RFC 3339, when the session started), `cwd`, `title`,
+and `git_branch`. `cwd` matters more than it looks: target stores encode it
+into the session's on-disk path, and `txcript continue` launches the target
+harness from it. `title` is what the target harness's listings and resume
+pickers show.
+
+```json
+{
+  "timestamp": "2026-08-18T10:00:00Z",
+  "cwd": "/Users/alice/src/myproj",
+  "git_branch": "main",
+  "title": "Pagination fix",
+  "messages": [ ... ]
+}
+```
+
+A document without a `timestamp` is stamped with the time it is first
+parsed. A message may carry its own `timestamp`; one without inherits the
+nearest preceding message's, or the session's.
+
+### L4 — identity
+
+`id` at the top level: the session's identifier, as the emitting agent
+knows it. Continuing into a live harness always mints a fresh id for the
+copy (so nothing can collide with the target's real sessions), but the
+original id is what exports and provenance refer back to. Absent, txcript
+derives one from the file name or generates a UUID.
+
+### L5 — accounting
+
+`usage` on assistant messages, and per-message `timestamp`s:
+
+```json
+{ "role": "assistant", "content": "Done.",
+  "timestamp": "2026-08-18T10:00:12Z",
+  "usage": { "input_tokens": 900, "output_tokens": 80,
+             "cache_read_input_tokens": 800 } }
+```
+
+`input_tokens` and `output_tokens` are required inside `usage` (integers);
+the two cache fields are optional. Omit `usage` entirely when unknown.
+
+### L6 — full
+
+The appendix tier: fields nobody hand-writes, present so a conversion *into*
+Simple from a real harness drops nothing.
+
+- `stop_reason` on assistant messages: why the turn ended. One of
+  `"end_turn"`, `"tool_use"`, `"max_tokens"`, `"stop_sequence"`,
+  `"aborted"`, `"error"`, or `{"other": "<verbatim reason>"}`.
+- `signature` and `encrypted` on `thinking` blocks: opaque provider
+  reasoning tokens (Anthropic signature, encrypted reasoning content),
+  carried so a round trip can replay them.
+- `image` blocks, Anthropic shape:
+  `{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "<base64>"}}`.
+- `cli_version` at the top level: the version of whatever produced the
+  session.
+
+## Tolerance
+
+The parser never rejects a document over one bad element:
+
+- A message that fails to parse (a malformed `timestamp`, `content` that is
+  neither string nor array) is preserved verbatim in the file and excluded
+  from the conversation.
+- A block with an unknown `type`, or a message with an unknown `role`, is
+  likewise preserved but not conversation.
+- Unknown keys — top-level, message-level, block-level — are preserved
+  through a same-format round trip. They do not cross into other harnesses.
+
+The only hard errors: the document is not valid JSON, or its top level is
+not an object with a `messages` array.
+
+## The format as types
+
+The whole schema, as structural TypeScript types. This block is
+self-contained — the reference to hand to a code generator (or an agent)
+writing an emitter. The types describe what an emitter writes; the parser
+is more tolerant, per the Tolerance section.
+
+```ts
+type SimpleDocument = {
+  id?: string;              // your agent's session id
+  timestamp?: string;       // RFC 3339 session start, e.g. "2026-08-18T10:00:00Z"
+  cwd?: string;             // working directory the session ran in
+  git_branch?: string;
+  title?: string;
+  cli_version?: string;     // version of the emitting agent
+  model?: string;           // primary model for the session
+  messages: Message[];
+};
+
+type Message = {
+  role: "user" | "assistant";
+  content: string | Block[];      // plain text, or Anthropic-style blocks
+  timestamp?: string;             // RFC 3339
+  model?: string;                 // overrides the session model for this turn
+  stop_reason?: StopReason;
+  usage?: Usage;
+};
+
+type Block =
+  | { type: "text"; text: string }
+  | { type: "thinking"; text: string; signature?: string; encrypted?: string }
+  // Omitted ids pair each id-less tool_result with the oldest unpaired
+  // tool_use, first-in-first-out. Canonical Claude tool names (Bash, Read,
+  // Write, Edit, MultiEdit) render as typed, native calls in the target
+  // harness; any other name passes through losslessly. A name starting
+  // with "/" is a user-invoked command.
+  | { type: "tool_use"; name: string; input?: unknown; id?: string }
+  // content: a string, or any JSON value. Rides on a "user" message.
+  | { type: "tool_result"; content?: unknown; tool_use_id?: string; is_error?: boolean }
+  | { type: "image"; source: { type: "base64"; media_type: string; data: string } };
+
+type StopReason =
+  | "end_turn" | "tool_use" | "max_tokens" | "stop_sequence" | "aborted" | "error"
+  | { other: string };
+
+type Usage = {
+  input_tokens: number;           // integers
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+};
+```
+
+Unknown extra keys are allowed at the document, message, and block level;
+they survive a Simple round trip but do not cross into other harnesses.
+
+## Caveats
+
+- Simple is the richest interchange surface in this collection: the
+  conversion to the canonical model is total (every modeled field has a
+  slot), so it also serves as a lossless *export* target. What other
+  harnesses cannot represent is lost when converting onward, not here.
+- There is no system-prompt slot, deliberately. No harness transports a
+  system prompt through conversion — each rebuilds its own environment on
+  resume — so a field here would silently die at the hub. Content the
+  conversation depends on belongs inline in `user` messages.
+- Unknown keys survive a Simple→Simple round trip only; conversion to
+  another harness carries the modeled fields.
+- Key order in written files is alphabetical (canonicalized by the JSON
+  serializer); round-trip fidelity is value-level, not byte-level.
+
+<details>
+<summary><strong>Prompt for AI agents</strong> — paste this when asking an agent to convert a transcript to Simple, or to write a transformer that emits it</summary>
+
+````
+Target format: "Simple", txcript's interchange JSON — one JSON object.
+Any transcript in this format can be continued in Claude Code, Codex, and
+other coding agents via `txcript continue <file> --with <harness>`.
+
+type Doc = {
+  messages: Msg[];                  // required; everything else optional
+  id?: string;                      // the source agent's session id
+  timestamp?: string;               // RFC 3339, e.g. "2026-08-18T10:00:00Z"
+  cwd?: string; git_branch?: string; title?: string;
+  cli_version?: string; model?: string;
+};
+type Msg = {
+  role: "user" | "assistant";
+  content: string | Block[];        // plain text, or Anthropic-style blocks
+  timestamp?: string; model?: string;
+  usage?: { input_tokens: number; output_tokens: number };  // integers
+};
+type Block =
+  | { type: "text"; text: string }
+  | { type: "thinking"; text: string }
+  | { type: "tool_use"; name: string; input?: unknown; id?: string }
+  | { type: "tool_result"; content?: unknown; tool_use_id?: string; is_error?: boolean }
+  | { type: "image"; source: { type: "base64"; media_type: string; data: string } };
+
+Rules:
+- Emit only fields you have; omit the rest entirely (never null).
+- A tool_result rides on the "user" message after its call. Ids are
+  optional: an id-less result pairs with the oldest unpaired tool_use.
+- Where a tool matches Claude's, use its name and argument keys —
+  Bash {command}, Read {file_path}, Write {file_path, content},
+  Edit {file_path, old_string, new_string} — it renders as a native tool
+  call in the target. Any other name passes through unchanged; both are
+  valid. A name starting with "/" is a user-invoked command.
+- Skill or command invocations are tool calls; their loaded content is
+  the paired tool_result.
+- Context the model saw but no tool produced (system reminders, injected
+  memory) goes inline in user content. Environment noise the next
+  harness regenerates (directory listings, git status) is best dropped.
+
+Full spec, including stop_reason and thinking signatures:
+https://github.com/skillsynchq/txcript/blob/main/docs/formats/simple.md
+````
+
+</details>
+
+## References
+
+Simple is defined by txcript; there is no upstream. The parser
+(`src/harness/simple.rs`) and the integration tests
+(`tests/integration/simple.rs`) are the normative mapping.
+
+Last verified: 2026-08-18 (format introduced).

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -15,6 +15,7 @@ pub mod cursor_desktop;
 pub mod grok;
 pub mod opencode;
 pub mod pi;
+pub mod simple;
 
 pub(crate) mod jsonl;
 

--- a/src/harness/simple.rs
+++ b/src/harness/simple.rs
@@ -1,0 +1,432 @@
+//! Simple — txcript's own interchange format, a pseudo-harness with no app
+//! behind it.
+//!
+//! The native format is a single JSON document: session metadata at the top
+//! level (all optional), and a `messages` array of `{role, content, …}`
+//! objects whose block shapes follow the Anthropic Messages API convention.
+//! `content` is a plain string or an array of `text` / `thinking` /
+//! `tool_use` / `tool_result` / `image` blocks. Almost everything is
+//! optional: missing tool ids are synthesized deterministically and id-less
+//! results pair FIFO with preceding unpaired calls; missing timestamps
+//! inherit the nearest preceding message's, then the session's. The format
+//! is specified level by level in `docs/formats/simple.md` — that document
+//! and this module are written to agree; when they drift, fix the document.
+//!
+//! Tolerance: a message that fails the typed parse, a block with an unknown
+//! `type`, and a message with an unknown role are preserved verbatim in the
+//! body ([`Record::Other`] or their raw fields) and excluded from the
+//! canonical conversation. Unknown keys at every level ride in flattened
+//! `extra` maps. Only a document that is not a JSON object with a `messages`
+//! array fails to parse.
+//!
+//! There is no [`Store`](crate::Store): a Simple session is a document
+//! handed to txcript directly (a file or stdin at the CLI, text at the WASM
+//! boundary), not something discovered from or written into a managed
+//! location — [`crate::local::write`] refuses the `simple` target
+//! accordingly. The codec itself stays symmetric so library and WASM users
+//! can render Simple text.
+//!
+//! Known losses: unknown keys and unmodeled records survive same-format
+//! round trips but do not cross [`Common`]; there is deliberately no
+//! system-prompt slot ([`Common`] has none, and every harness rebuilds its
+//! own environment on resume). Within the modeled fields the codec is a
+//! projection of [`Common`] itself, so `to_common(from_common(c)) == c`
+//! holds for any canonical transcript `c`.
+
+use std::collections::VecDeque;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use uuid::Uuid;
+
+use crate::common::{Block, ImageSource, Message, Meta, Role, StopReason, Tool, ToolOutput, Usage};
+use crate::error::{Error, Result};
+use crate::transcript::{Codec, Common, Harness, TextCodec, Transcript};
+
+/// The Simple harness marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Simple;
+
+impl Harness for Simple {
+    const NAME: &'static str = "simple";
+    type Body = Doc;
+}
+
+/// The native body: the document's message entries plus any unknown
+/// top-level keys. The modeled top-level metadata (`id`, `timestamp`, `cwd`,
+/// `git_branch`, `title`, `cli_version`, `model`) lives in [`Meta`] and is
+/// re-rendered from it.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Doc {
+    pub records: Vec<Record>,
+    /// Unknown top-level keys, preserved through same-format round trips.
+    pub extra: Map<String, Value>,
+}
+
+/// One element of the `messages` array: a parsed message, or — when the
+/// typed parse fails (malformed timestamp, non-string-non-array content) —
+/// the element preserved verbatim.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum Record {
+    Message(Entry),
+    Other(Value),
+}
+
+/// A message as written on the wire. Every field is optional but `role` and
+/// `content` are what make it conversation: an entry whose role is not
+/// `user`/`assistant` is preserved but contributes nothing to [`Common`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Entry {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub role: String,
+    #[serde(default, skip_serializing_if = "Content::is_empty_blocks")]
+    pub content: Content,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<StopReason>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
+    /// Unknown message-level keys, preserved.
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
+}
+
+/// Message content: the L0 plain string, or an array of blocks. Blocks stay
+/// raw [`Value`]s in the body — the codec interprets them, serde stays
+/// lossless.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Content {
+    Text(String),
+    Blocks(Vec<Value>),
+}
+
+impl Default for Content {
+    fn default() -> Self {
+        Content::Blocks(Vec::new())
+    }
+}
+
+impl Content {
+    /// True for the default empty block array, so an absent `content` key
+    /// stays absent on render.
+    fn is_empty_blocks(&self) -> bool {
+        matches!(self, Content::Blocks(blocks) if blocks.is_empty())
+    }
+}
+
+fn malformed(detail: impl Into<String>) -> Error {
+    Error::Malformed {
+        harness: Simple::NAME,
+        detail: detail.into(),
+    }
+}
+
+// ── codec ──────────────────────────────────────────────────────────────
+
+impl Codec for Simple {
+    fn to_common(transcript: &Transcript<Self>) -> Result<Transcript<Common>> {
+        let mut messages = Vec::new();
+        // A message without a timestamp inherits the nearest preceding one.
+        let mut last_ts = transcript.meta.timestamp;
+        // Unpaired tool_use ids in emission order, for id-less results.
+        let mut pending: VecDeque<String> = VecDeque::new();
+        for (i, record) in transcript.body.records.iter().enumerate() {
+            let Record::Message(entry) = record else {
+                continue;
+            };
+            let role = match entry.role.trim().to_ascii_lowercase().as_str() {
+                "user" => Role::User,
+                "assistant" => Role::Assistant,
+                // Unknown roles are not conversation; they stay in the body.
+                _ => continue,
+            };
+            let timestamp = entry.timestamp.unwrap_or(last_ts);
+            last_ts = timestamp;
+            let content = match &entry.content {
+                Content::Text(text) => vec![Block::Text { text: text.clone() }],
+                Content::Blocks(blocks) => blocks
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(j, block)| {
+                        block_to_common(block, &transcript.meta.id, i, j, &mut pending)
+                    })
+                    .collect(),
+            };
+            messages.push(Message {
+                role,
+                content,
+                timestamp,
+                model: entry.model.clone(),
+                stop_reason: entry.stop_reason.clone(),
+                usage: entry.usage,
+            });
+        }
+        Ok(Transcript::new(transcript.meta.clone(), messages))
+    }
+
+    fn from_common(transcript: &Transcript<Common>) -> Result<Transcript<Self>> {
+        let records = transcript.body.iter().map(entry_from_common).collect();
+        Ok(Transcript::new(
+            transcript.meta.clone(),
+            Doc {
+                records,
+                extra: Map::new(),
+            },
+        ))
+    }
+}
+
+/// Interpret one raw block [`Value`]. `None` — an unknown `type` or a known
+/// type missing its defining field — drops the block from [`Common`]; it
+/// still lives in the body.
+fn block_to_common(
+    block: &Value,
+    session_id: &str,
+    i: usize,
+    j: usize,
+    pending: &mut VecDeque<String>,
+) -> Option<Block> {
+    match block.get("type").and_then(Value::as_str)? {
+        "text" => Some(Block::Text {
+            text: block.get("text")?.as_str()?.to_string(),
+        }),
+        "thinking" => Some(Block::Thinking {
+            text: block.get("text")?.as_str()?.to_string(),
+            signature: str_field(block, "signature"),
+            encrypted: str_field(block, "encrypted"),
+        }),
+        "tool_use" => {
+            let name = block.get("name")?.as_str()?;
+            let input = block.get("input").cloned().unwrap_or(Value::Null);
+            let id = str_field(block, "id").unwrap_or_else(|| synth_id(session_id, i, j));
+            pending.push_back(id.clone());
+            Some(Block::ToolUse {
+                id,
+                tool: Tool::from_canonical(name, input),
+            })
+        }
+        "tool_result" => {
+            let tool_use_id = match str_field(block, "tool_use_id") {
+                Some(id) => {
+                    // An explicitly paired call is no longer pending.
+                    if let Some(pos) = pending.iter().position(|p| *p == id) {
+                        pending.remove(pos);
+                    }
+                    id
+                }
+                // FIFO: the oldest unpaired call, per the Anthropic ordering
+                // convention; a result with no call at all still gets a
+                // stable synthetic id.
+                None => pending
+                    .pop_front()
+                    .unwrap_or_else(|| synth_id(session_id, i, j)),
+            };
+            let content = match block.get("content") {
+                None => ToolOutput::Text(String::new()),
+                Some(Value::String(text)) => ToolOutput::Text(text.clone()),
+                Some(other) => ToolOutput::Json(other.clone()),
+            };
+            Some(Block::ToolResult {
+                tool_use_id,
+                content,
+                is_error: block
+                    .get("is_error")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            })
+        }
+        "image" => ImageSource::deserialize(block.get("source")?)
+            .ok()
+            .map(|source| Block::Image { source }),
+        _ => None,
+    }
+}
+
+fn str_field(value: &Value, key: &str) -> Option<String> {
+    value.get(key).and_then(Value::as_str).map(String::from)
+}
+
+/// Deterministic id for a `tool_use` without one (and for a `tool_result`
+/// with neither an id nor a pending call): pure function of the session id
+/// and the message/block index.
+fn synth_id(session_id: &str, i: usize, j: usize) -> String {
+    const NS: Uuid = Uuid::from_bytes(*b"txcript-simple!!");
+    Uuid::new_v5(&NS, format!("{session_id}:{i}:{j}").as_bytes()).to_string()
+}
+
+fn entry_from_common(message: &Message) -> Record {
+    let content = match message.content.as_slice() {
+        // The L0 shorthand: a single text block renders as a plain string.
+        [Block::Text { text }] => Content::Text(text.clone()),
+        blocks => Content::Blocks(blocks.iter().map(block_to_value).collect()),
+    };
+    Record::Message(Entry {
+        role: match message.role {
+            Role::User => "user",
+            Role::Assistant => "assistant",
+        }
+        .to_string(),
+        content,
+        timestamp: Some(message.timestamp),
+        model: message.model.clone(),
+        stop_reason: message.stop_reason.clone(),
+        usage: message.usage,
+        extra: Map::new(),
+    })
+}
+
+fn block_to_value(block: &Block) -> Value {
+    match block {
+        Block::Text { text } => json!({"type": "text", "text": text}),
+        Block::Thinking {
+            text,
+            signature,
+            encrypted,
+        } => {
+            let mut map = Map::new();
+            map.insert("type".into(), json!("thinking"));
+            map.insert("text".into(), json!(text));
+            if let Some(signature) = signature {
+                map.insert("signature".into(), json!(signature));
+            }
+            if let Some(encrypted) = encrypted {
+                map.insert("encrypted".into(), json!(encrypted));
+            }
+            Value::Object(map)
+        }
+        Block::ToolUse { id, tool } => {
+            let (name, input) = tool.to_canonical();
+            json!({"type": "tool_use", "id": id, "name": name, "input": input})
+        }
+        Block::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+        } => {
+            let mut map = Map::new();
+            map.insert("type".into(), json!("tool_result"));
+            map.insert("tool_use_id".into(), json!(tool_use_id));
+            map.insert(
+                "content".into(),
+                match content {
+                    ToolOutput::Text(text) => Value::String(text.clone()),
+                    ToolOutput::Json(value) => value.clone(),
+                },
+            );
+            if *is_error {
+                map.insert("is_error".into(), Value::Bool(true));
+            }
+            Value::Object(map)
+        }
+        Block::Image { source } => json!({"type": "image", "source": {
+            "type": source.source_type,
+            "media_type": source.media_type,
+            "data": source.data,
+        }}),
+    }
+}
+
+// ── text codec ─────────────────────────────────────────────────────────
+
+impl TextCodec for Simple {
+    fn from_text(text: &str) -> Result<Transcript<Self>> {
+        let document: Value = serde_json::from_str(text)?;
+        let Value::Object(mut map) = document else {
+            return Err(malformed("top level is not a JSON object"));
+        };
+        let messages = match map.remove("messages") {
+            Some(Value::Array(messages)) => messages,
+            Some(_) => return Err(malformed("`messages` is not an array")),
+            None => return Err(malformed("no `messages` array")),
+        };
+        let records = messages.into_iter().map(record).collect();
+        // The timestamp is extracted only when it parses; any other value
+        // stays in `extra` (and wins on render), so an odd document round
+        // trips rather than losing the field.
+        let timestamp = map
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .and_then(|s| s.parse::<DateTime<Utc>>().ok());
+        if timestamp.is_some() {
+            map.remove("timestamp");
+        }
+        let meta = Meta {
+            id: take_str(&mut map, "id").unwrap_or_default(),
+            timestamp: timestamp.unwrap_or_else(Utc::now),
+            cwd: take_str(&mut map, "cwd"),
+            git_branch: take_str(&mut map, "git_branch"),
+            title: take_str(&mut map, "title"),
+            cli_version: take_str(&mut map, "cli_version"),
+            model: take_str(&mut map, "model"),
+        };
+        Ok(Transcript::new(
+            meta,
+            Doc {
+                records,
+                extra: map,
+            },
+        ))
+    }
+
+    fn to_text(transcript: &Transcript<Self>) -> Result<String> {
+        let meta = &transcript.meta;
+        let mut map = Map::new();
+        if !meta.id.is_empty() {
+            map.insert("id".into(), json!(meta.id));
+        }
+        map.insert(
+            "timestamp".into(),
+            json!(meta.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true)),
+        );
+        for (key, value) in [
+            ("cwd", &meta.cwd),
+            ("git_branch", &meta.git_branch),
+            ("title", &meta.title),
+            ("cli_version", &meta.cli_version),
+            ("model", &meta.model),
+        ] {
+            if let Some(value) = value {
+                map.insert(key.into(), json!(value));
+            }
+        }
+        map.insert(
+            "messages".into(),
+            serde_json::to_value(&transcript.body.records)?,
+        );
+        // Unknown top-level keys last: on the rare collision (a `timestamp`
+        // that never parsed), the preserved original wins.
+        for (key, value) in &transcript.body.extra {
+            map.insert(key.clone(), value.clone());
+        }
+        let mut out = serde_json::to_string_pretty(&Value::Object(map))?;
+        out.push('\n');
+        Ok(out)
+    }
+}
+
+/// Parse one `messages` element; a failed typed parse preserves the element
+/// verbatim instead of erroring or dropping it.
+fn record(value: Value) -> Record {
+    match Entry::deserialize(&value) {
+        Ok(entry) => Record::Message(entry),
+        Err(_) => Record::Other(value),
+    }
+}
+
+/// Remove and return `key` only when it holds a string; other shapes stay in
+/// the map as preserved unknowns.
+fn take_str(map: &mut Map<String, Value>, key: &str) -> Option<String> {
+    if !map.get(key).is_some_and(Value::is_string) {
+        return None;
+    }
+    match map.remove(key) {
+        Some(Value::String(s)) => Some(s),
+        _ => None,
+    }
+}

--- a/src/local.rs
+++ b/src/local.rs
@@ -349,6 +349,15 @@ pub fn write(
             common,
             |s| s.root,
         ),
+        // Simple is an interchange *input*: documents are handed to txcript
+        // directly (a file, stdin, the WASM text API) rather than managed in
+        // a directory of its own, so there is nowhere to write one back to.
+        HarnessId::Simple => Err(Error::Unconvertible {
+            harness: "simple",
+            detail: "simple is an interchange input; sessions are continued \
+                     from Simple documents, not written into them"
+                .to_string(),
+        }),
         // `opencode import` writes into the live database wherever it lives;
         // honoring a root override is impossible, and ignoring it would send
         // an "export" into the user's real store.
@@ -436,6 +445,9 @@ pub fn resume_command(harness: HarnessId, id: &str) -> (String, Vec<String>) {
             HarnessId::Grok => ("grok".into(), vec!["--resume".into(), id]),
             HarnessId::Amp => ("amp".into(), vec!["threads".into(), "continue".into(), id]),
             HarnessId::Antigravity => ("agy".into(), vec![format!("--conversation={id}")]),
+            // Unreachable in practice: Simple sessions are neither discovered
+            // nor written, so nothing resumes one. There is no native app.
+            HarnessId::Simple => ("txcript".into(), Vec::new()),
         }
     })
 }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -242,10 +242,11 @@ pub enum HarnessId {
     Grok,
     Amp,
     Antigravity,
+    Simple,
 }
 
 impl HarnessId {
-    pub const ALL: [HarnessId; 10] = [
+    pub const ALL: [HarnessId; 11] = [
         HarnessId::ClaudeCode,
         HarnessId::Codex,
         HarnessId::OpenCode,
@@ -256,6 +257,7 @@ impl HarnessId {
         HarnessId::Grok,
         HarnessId::Amp,
         HarnessId::Antigravity,
+        HarnessId::Simple,
     ];
 
     /// The stable lowercase name, matching the corresponding [`Harness::NAME`].
@@ -272,6 +274,7 @@ impl HarnessId {
             HarnessId::Grok => "grok",
             HarnessId::Amp => "amp",
             HarnessId::Antigravity => "antigravity",
+            HarnessId::Simple => "simple",
         }
     }
 }
@@ -304,6 +307,7 @@ impl FromStr for HarnessId {
             "antigravity" | "agy" | "antigravity_cli" | "antigravity-cli" | "anti-gravity" => {
                 Ok(HarnessId::Antigravity)
             }
+            "simple" | "simple_json" | "simple-json" => Ok(HarnessId::Simple),
             other => Err(crate::error::Error::UnknownHarness(other.to_string())),
         }
     }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -15,6 +15,7 @@ use wasm_bindgen::prelude::*;
 use crate::common;
 use crate::harness::{
     amp, antigravity, campfire, claude_code, codex, cursor, cursor_desktop, grok, opencode, pi,
+    simple,
 };
 use crate::transcript::{Codec, Common, HarnessId, TextCodec, Transcript};
 
@@ -25,10 +26,10 @@ use crate::transcript::{Codec, Common, HarnessId, TextCodec, Transcript};
 /// database rows for `cursor_desktop`, the `opencode export` JSON for
 /// opencode, the JSON bundle of the session directory for grok, the thread
 /// JSON document for amp, the JSON dump of the conversation database for
-/// antigravity); `from`/`to` are harness names (`"claude_code"`, `"codex"`,
-/// `"opencode"`, `"pi"`, `"campfire"`, `"cursor"`, `"cursor_desktop"`,
-/// `"grok"`, `"amp"`, `"antigravity"`). Returns the target harness's native
-/// text.
+/// antigravity, the interchange JSON document for simple); `from`/`to` are
+/// harness names (`"claude_code"`, `"codex"`, `"opencode"`, `"pi"`,
+/// `"campfire"`, `"cursor"`, `"cursor_desktop"`, `"grok"`, `"amp"`,
+/// `"antigravity"`, `"simple"`). Returns the target harness's native text.
 #[wasm_bindgen]
 pub fn convert(input: &str, from: &str, to: &str) -> Result<String, JsError> {
     parse_harness(from)
@@ -201,6 +202,7 @@ fn parse_to_common(harness: HarnessId, text: &str) -> crate::Result<Transcript<C
         HarnessId::Grok => go::<grok::Grok>(text),
         HarnessId::Amp => go::<amp::Amp>(text),
         HarnessId::Antigravity => go::<antigravity::Antigravity>(text),
+        HarnessId::Simple => go::<simple::Simple>(text),
     }
 }
 
@@ -219,6 +221,7 @@ fn render_from_common(harness: HarnessId, common: &Transcript<Common>) -> crate:
         HarnessId::Grok => go::<grok::Grok>(common),
         HarnessId::Amp => go::<amp::Amp>(common),
         HarnessId::Antigravity => go::<antigravity::Antigravity>(common),
+        HarnessId::Simple => go::<simple::Simple>(common),
     }
 }
 

--- a/tests/integration/cross_harness.rs
+++ b/tests/integration/cross_harness.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use txcript::common;
 use txcript::harness::{
     amp, antigravity, campfire, claude_code, codex, cursor, cursor_desktop, grok, opencode, pi,
+    simple,
 };
 use txcript::{Codec, Common, Transcript, convert};
 
@@ -198,8 +199,15 @@ fn conversation_survives_every_hop() {
         "antigravity"
     );
 
+    let simple = convert::<antigravity::Antigravity, simple::Simple>(&antigravity).unwrap();
+    assert_eq!(
+        signature(&simple::Simple::to_common(&simple).unwrap()),
+        expected,
+        "simple"
+    );
+
     // And all the way back to Claude.
-    let round = convert::<antigravity::Antigravity, claude_code::ClaudeCode>(&antigravity).unwrap();
+    let round = convert::<simple::Simple, claude_code::ClaudeCode>(&simple).unwrap();
     assert_eq!(
         signature(&claude_code::ClaudeCode::to_common(&round).unwrap()),
         expected,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -18,6 +18,7 @@ mod opencode;
 mod path_safety;
 mod pi;
 mod properties;
+mod simple;
 mod store_delete;
 
 #[cfg(feature = "search")]

--- a/tests/integration/properties.rs
+++ b/tests/integration/properties.rs
@@ -19,6 +19,7 @@ use serde_json::json;
 use txcript::common::{Block, Message, Meta, Role, Tool, ToolOutput};
 use txcript::harness::{
     amp, antigravity, campfire, claude_code, codex, cursor, cursor_desktop, grok, opencode, pi,
+    simple,
 };
 use txcript::{Codec, Common, Transcript};
 
@@ -263,5 +264,6 @@ proptest! {
         assert_fixpoint::<grok::Grok>("grok", &common)?;
         assert_fixpoint::<amp::Amp>("amp", &common)?;
         assert_fixpoint::<antigravity::Antigravity>("antigravity", &common)?;
+        assert_fixpoint::<simple::Simple>("simple", &common)?;
     }
 }

--- a/tests/integration/simple.rs
+++ b/tests/integration/simple.rs
@@ -1,0 +1,378 @@
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
+//! Integration tests for the Simple interchange format — the leniency
+//! ladder (string content, missing ids, missing timestamps), unknown-key
+//! preservation at every level, and the codec fixpoint through Common.
+
+use chrono::{DateTime, Utc};
+use serde_json::{Value, json};
+use txcript::common;
+use txcript::harness::simple;
+use txcript::{Codec, Common, TextCodec, Transcript};
+
+fn ts(s: &str) -> DateTime<Utc> {
+    s.parse().unwrap()
+}
+
+/// A native document exercising every rung of the ladder (anonymized): L0
+/// string content, blocks with and without explicit ids, full metadata, an
+/// unknown top-level key, an unknown message key, an unknown block type, an
+/// unknown role, and one malformed message that must survive as a raw
+/// record.
+fn native_fixture() -> Value {
+    json!({
+        "id": "simple-fixture-1",
+        "timestamp": "2026-08-18T10:00:00.000Z",
+        "cwd": "/Users/dev/proj",
+        "git_branch": "main",
+        "title": "Pagination fix",
+        "cli_version": "0.1.0",
+        "model": "claude-opus-5",
+        "generator": "my-agent/0.1",
+        "messages": [
+            { "role": "user", "content": "fix the off-by-one", "mood": "hopeful" },
+            { "role": "assistant", "content": [
+                { "type": "thinking", "text": "the bound is inclusive" },
+                { "type": "tool_use", "name": "Bash", "input": { "command": "cargo test" } },
+            ], "model": "claude-opus-5", "stop_reason": "tool_use" },
+            { "role": "user", "content": [
+                { "type": "tool_result", "content": "42 passed" },
+            ] },
+            { "role": "assistant", "content": [
+                { "type": "tool_use", "id": "call-x", "name": "my_probe", "input": { "q": 1 } },
+                { "type": "vibes", "intensity": 11 },
+            ] },
+            { "role": "user", "content": [
+                { "type": "tool_result", "tool_use_id": "call-x", "content": { "hits": [1, 2] }, "is_error": true },
+            ] },
+            { "role": "assistant", "content": "Done.",
+              "timestamp": "2026-08-18T10:00:12.000Z",
+              "usage": { "input_tokens": 900, "output_tokens": 80 } },
+            { "role": "system", "content": "you are a helpful agent" },
+            { "role": "user", "content": "thanks", "timestamp": "not-a-timestamp" },
+        ],
+    })
+}
+
+#[test]
+fn text_round_trip_is_lossless() {
+    let first = simple::Simple::from_text(&native_fixture().to_string()).unwrap();
+    let second = simple::Simple::from_text(&simple::Simple::to_text(&first).unwrap()).unwrap();
+    assert_eq!(first, second);
+
+    // The malformed message survives as a raw record, verbatim.
+    assert!(first.body.records.iter().any(|r| matches!(
+        r,
+        simple::Record::Other(v) if v.get("timestamp").and_then(Value::as_str) == Some("not-a-timestamp")
+    )));
+    // Unknown keys survive at the top level and on messages.
+    assert_eq!(
+        first.body.extra.get("generator"),
+        Some(&json!("my-agent/0.1"))
+    );
+    assert!(first.body.records.iter().any(|r| matches!(
+        r,
+        simple::Record::Message(m) if m.extra.get("mood") == Some(&json!("hopeful"))
+    )));
+}
+
+#[test]
+fn from_text_extracts_metadata() {
+    let meta = simple::Simple::from_text(&native_fixture().to_string())
+        .unwrap()
+        .meta;
+    assert_eq!(meta.id, "simple-fixture-1");
+    assert_eq!(meta.timestamp, ts("2026-08-18T10:00:00Z"));
+    assert_eq!(meta.cwd.as_deref(), Some("/Users/dev/proj"));
+    assert_eq!(meta.git_branch.as_deref(), Some("main"));
+    assert_eq!(meta.title.as_deref(), Some("Pagination fix"));
+    assert_eq!(meta.cli_version.as_deref(), Some("0.1.0"));
+    assert_eq!(meta.model.as_deref(), Some("claude-opus-5"));
+}
+
+#[test]
+fn to_common_extracts_the_full_ladder() {
+    let native = simple::Simple::from_text(&native_fixture().to_string()).unwrap();
+
+    let common = simple::Simple::to_common(&native).unwrap();
+    // The system-role and malformed messages are not conversation.
+    assert_eq!(common.body.len(), 6);
+
+    // L0 string content becomes a text block.
+    assert_eq!(
+        common.body[0].content,
+        vec![common::Block::Text {
+            text: "fix the off-by-one".into()
+        }]
+    );
+
+    // A canonical name types the tool; the id-less call gets a synthetic id
+    // that the id-less result pairs with, FIFO.
+    let call_id = match &common.body[1].content[1] {
+        common::Block::ToolUse {
+            id,
+            tool: common::Tool::Bash { command, .. },
+        } => {
+            assert_eq!(command, "cargo test");
+            id.clone()
+        }
+        other => panic!("expected a typed Bash call, got {other:?}"),
+    };
+    assert_eq!(
+        common.body[2].content,
+        vec![common::Block::ToolResult {
+            tool_use_id: call_id,
+            content: common::ToolOutput::Text("42 passed".into()),
+            is_error: false,
+        }]
+    );
+    assert_eq!(common.body[1].model.as_deref(), Some("claude-opus-5"));
+    assert_eq!(
+        common.body[1].stop_reason,
+        Some(common::StopReason::ToolUse)
+    );
+
+    // A free-form name passes through as Raw; the unknown block type drops.
+    assert_eq!(common.body[3].content.len(), 1);
+    assert_eq!(
+        common.body[3].content[0],
+        common::Block::ToolUse {
+            id: "call-x".into(),
+            tool: common::Tool::Raw {
+                tool_name: "my_probe".into(),
+                input: json!({"q": 1})
+            },
+        }
+    );
+    // An explicit pairing with JSON output and the error flag.
+    assert_eq!(
+        common.body[4].content,
+        vec![common::Block::ToolResult {
+            tool_use_id: "call-x".into(),
+            content: common::ToolOutput::Json(json!({"hits": [1, 2]})),
+            is_error: true,
+        }]
+    );
+
+    // Timestamps: absent inherits the nearest preceding (here the session's),
+    // explicit is kept, and usage lands where written.
+    assert_eq!(common.body[0].timestamp, ts("2026-08-18T10:00:00Z"));
+    assert_eq!(common.body[5].timestamp, ts("2026-08-18T10:00:12Z"));
+    assert_eq!(
+        common.body[5].usage,
+        Some(common::Usage {
+            input_tokens: 900,
+            output_tokens: 80,
+            cache_read_input_tokens: None,
+            cache_creation_input_tokens: None,
+        })
+    );
+}
+
+/// A canonical transcript at full fidelity: every block type, typed and raw
+/// tools, JSON and error results, provider reasoning tokens, usage, stop
+/// reasons, an image, and a single-text message (the L0 shorthand path).
+#[allow(clippy::too_many_lines)]
+fn rich_common() -> Transcript<Common> {
+    let meta = common::Meta {
+        id: "fix-42".into(),
+        timestamp: ts("2026-08-18T10:00:00Z"),
+        cwd: Some("/Users/dev/proj".into()),
+        git_branch: Some("main".into()),
+        title: Some("Pagination fix".into()),
+        cli_version: Some("0.1.0".into()),
+        model: Some("claude-opus-5".into()),
+    };
+    let body = vec![
+        common::Message {
+            role: common::Role::User,
+            content: vec![common::Block::Text {
+                text: "fix it".into(),
+            }],
+            timestamp: ts("2026-08-18T10:00:01Z"),
+            model: None,
+            stop_reason: None,
+            usage: None,
+        },
+        common::Message {
+            role: common::Role::Assistant,
+            content: vec![
+                common::Block::Thinking {
+                    text: "inclusive bound".into(),
+                    signature: Some("sig-abc".into()),
+                    encrypted: None,
+                },
+                common::Block::ToolUse {
+                    id: "call-1".into(),
+                    tool: common::Tool::Edit {
+                        file_path: "/Users/dev/proj/a.rs".into(),
+                        old_string: "i <= n".into(),
+                        new_string: "i < n".into(),
+                        replace_all: false,
+                    },
+                },
+            ],
+            timestamp: ts("2026-08-18T10:00:02Z"),
+            model: Some("claude-opus-5".into()),
+            stop_reason: Some(common::StopReason::ToolUse),
+            usage: Some(common::Usage {
+                input_tokens: 900,
+                output_tokens: 80,
+                cache_read_input_tokens: Some(800),
+                cache_creation_input_tokens: None,
+            }),
+        },
+        common::Message {
+            role: common::Role::User,
+            content: vec![common::Block::ToolResult {
+                tool_use_id: "call-1".into(),
+                content: common::ToolOutput::Json(json!({"applied": true})),
+                is_error: false,
+            }],
+            timestamp: ts("2026-08-18T10:00:03Z"),
+            model: None,
+            stop_reason: None,
+            usage: None,
+        },
+        common::Message {
+            role: common::Role::Assistant,
+            content: vec![common::Block::ToolUse {
+                id: "call-2".into(),
+                tool: common::Tool::Raw {
+                    tool_name: "my_probe".into(),
+                    input: json!({"q": 1}),
+                },
+            }],
+            timestamp: ts("2026-08-18T10:00:04Z"),
+            model: Some("claude-opus-5".into()),
+            stop_reason: None,
+            usage: None,
+        },
+        common::Message {
+            role: common::Role::User,
+            content: vec![
+                common::Block::ToolResult {
+                    tool_use_id: "call-2".into(),
+                    content: common::ToolOutput::Text("probe failed".into()),
+                    is_error: true,
+                },
+                common::Block::Image {
+                    source: common::ImageSource {
+                        source_type: "base64".into(),
+                        media_type: "image/png".into(),
+                        data: "aGk=".into(),
+                    },
+                },
+            ],
+            timestamp: ts("2026-08-18T10:00:05Z"),
+            model: None,
+            stop_reason: None,
+            usage: None,
+        },
+        common::Message {
+            role: common::Role::Assistant,
+            content: vec![common::Block::Text {
+                text: "Done.".into(),
+            }],
+            timestamp: ts("2026-08-18T10:00:06Z"),
+            model: Some("claude-opus-5".into()),
+            stop_reason: Some(common::StopReason::EndTurn),
+            usage: None,
+        },
+    ];
+    Transcript::new(meta, body)
+}
+
+#[test]
+fn codec_fixpoint_through_common_loses_nothing() {
+    let common = rich_common();
+    let native = simple::Simple::from_common(&common).unwrap();
+    let back = simple::Simple::to_common(&native).unwrap();
+    assert_eq!(common, back);
+}
+
+#[test]
+fn text_round_trip_preserves_the_native_body() {
+    let common = rich_common();
+    let native = simple::Simple::from_common(&common).unwrap();
+    let text = simple::Simple::to_text(&native).unwrap();
+    let reparsed = simple::Simple::from_text(&text).unwrap();
+    assert_eq!(native, reparsed);
+}
+
+#[test]
+fn from_common_is_deterministic() {
+    let common = rich_common();
+    let a = simple::Simple::to_text(&simple::Simple::from_common(&common).unwrap()).unwrap();
+    let b = simple::Simple::to_text(&simple::Simple::from_common(&common).unwrap()).unwrap();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn barebones_document_is_enough() {
+    let text = r#"{"messages": [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"}
+    ]}"#;
+    let native = simple::Simple::from_text(text).unwrap();
+    let common = simple::Simple::to_common(&native).unwrap();
+    assert_eq!(common.body.len(), 2);
+    assert_eq!(common.body[0].role, common::Role::User);
+    assert_eq!(
+        common.body[1].content,
+        vec![common::Block::Text {
+            text: "hello".into()
+        }]
+    );
+    // Both messages inherit the synthesized session timestamp.
+    assert_eq!(common.body[0].timestamp, common.meta.timestamp);
+}
+
+#[test]
+fn documents_without_a_messages_array_are_rejected() {
+    assert!(simple::Simple::from_text("[]").is_err());
+    assert!(simple::Simple::from_text(r#"{"not": "simple"}"#).is_err());
+    assert!(simple::Simple::from_text(r#"{"messages": 5}"#).is_err());
+    assert!(simple::Simple::from_text("not json").is_err());
+}
+
+#[test]
+fn id_less_results_pair_fifo_across_interleaved_calls() {
+    let text = json!({
+        "id": "s",
+        "timestamp": "2026-08-18T10:00:00Z",
+        "messages": [
+            { "role": "assistant", "content": [
+                { "type": "tool_use", "name": "Bash", "input": { "command": "a" } },
+                { "type": "tool_use", "name": "Bash", "input": { "command": "b" } },
+            ] },
+            { "role": "user", "content": [
+                { "type": "tool_result", "content": "out-a" },
+                { "type": "tool_result", "content": "out-b" },
+            ] },
+        ],
+    })
+    .to_string();
+    let common = simple::Simple::to_common(&simple::Simple::from_text(&text).unwrap()).unwrap();
+
+    let call = |block: &common::Block| match block {
+        common::Block::ToolUse { id, .. } => id.clone(),
+        other => panic!("expected a call, got {other:?}"),
+    };
+    let result = |block: &common::Block| match block {
+        common::Block::ToolResult { tool_use_id, .. } => tool_use_id.clone(),
+        other => panic!("expected a result, got {other:?}"),
+    };
+    assert_eq!(
+        call(&common.body[0].content[0]),
+        result(&common.body[1].content[0])
+    );
+    assert_eq!(
+        call(&common.body[0].content[1]),
+        result(&common.body[1].content[1])
+    );
+    assert_ne!(
+        result(&common.body[1].content[0]),
+        result(&common.body[1].content[1])
+    );
+}


### PR DESCRIPTION
**Stack: 1/3** — base of the stacked-PR series: #3 → #6 → #1.

Simple is txcript's own documented interchange format: a pseudo-harness with no app behind it and — deliberately — no store. Any agent, including ones txcript has never heard of, emits a single JSON document; the document itself is the session, handed to txcript directly (#4 adds `txcript continue <file|-> --with <harness>`). There is no managed directory, no discovery, and nothing to list: once continued, the conversation lives in the target harness.

### Format

Specified in [`docs/formats/simple.md`](docs/formats/simple.md) as a fidelity ladder — every level is the same schema read further, nothing enforced per level:

- **L0** `{"messages": [{"role", "content": "string"}]}` — already enough to continue into Claude Code
- **L1** Anthropic-convention blocks: `text`, `thinking`, `tool_use`, `tool_result`, `image`; optional tool ids (FIFO pairing when absent), free-form tool names pass through as `Raw`, canonical Claude names render typed; skills and `/commands` are just tool calls
- **L2–L5** model, session metadata (`cwd`, `title`, …), `id`, `usage`/timestamps
- **L6** `stop_reason`, thinking signatures — the export-fidelity appendix

The spec closes with the whole schema as structural TypeScript types — a self-contained block for pointing a code generator (or an agent) at when writing an emitter.

Tolerance follows the repo doctrine: malformed messages, unknown roles, and unknown block types are preserved verbatim and excluded from `Common`; unknown keys ride flattened `extra` maps. The codec is a projection of `Common`, so `to_common(from_common(c)) == c` holds over the whole canonical model.

### Implementation

- `src/harness/simple.rs`: Body (`Doc` — typed message envelope, raw-`Value` blocks), `Codec`, `TextCodec`. No `Store`: Simple is an interchange *input*; `local::write` refuses the `simple` target, while the codec stays symmetric for library and WASM users.
- Wiring: `HarnessId::Simple`, WASM dispatch (both directions), CLI id and list color
- Tests: text-level lossless round trip incl. unmodeled records, metadata extraction, ladder extraction, exact codec fixpoint, determinism, FIFO pairing; plus Simple in the proptest sweep and the cross-harness chain

### Verification

`cargo test` (both feature sets), clippy pedantic, fmt, and the wasm32 target all clean. End to end (via #4's CLI surface): a Simple document continued into the live Claude Code store resumes under the real `claude` CLI answering questions from the converted history.

Deferred to follow-ups: syncing the ten README translations ("10 harnesses" → 11), and a corpus-check run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

