### PR TITLE
Continue a Simple document from a file or stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tempfile",
  "terminal_size",
  "tokio",
  "txcript",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,10 +82,13 @@ harness = false
 required-features = ["search"]
 
 [features]
-default = ["opencode", "search"]
+default = ["opencode", "hermes", "search"]
 # The OpenCode harness store reads OpenCode's SQLite database. The OpenCode
 # codec itself is always available; only the on-disk store needs rusqlite.
 opencode = ["dep:rusqlite"]
+# Hermes Agent's canonical session store is SQLite. The JSON export codec is
+# always available; only local discovery/loading needs rusqlite.
+hermes = ["dep:rusqlite"]
 # Fuzzy/substring search over transcripts (`txcript::search`). nucleo-matcher
 # is pure Rust (helix's matcher) and compiles to wasm32; combine with `wasm`
 # to expose the bindings.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--from <harness>]                    #   scope the id lookup to one harness
     [--out <dir>]                         #   write under <dir>; implies --no-resume
     [--no-resume]                         #   write the session but don't launch
+txcript continue <file|->[#range]        # continue a Simple document instead:
+    --with <harness> [...]                #   a file, or stdin (`-`), from any agent
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
 ```
@@ -132,6 +134,7 @@ txcript view <id>[#range]                # print a session as compact text
 
 - Same-harness: resumes the original in place.
 - Cross-harness (`--with`): re-synthesizes the session into the target's native format. What is written is always a copy; the source session is never modified or removed.
+- A [Simple](docs/formats/simple.md) document instead of an id — `txcript continue ./run.json --with claude_code`, or `my-agent | txcript continue - --with claude_code` — brings any agent's transcript in the same way; `--with` is required since a document has no harness of its own.
 - The launch command is per-harness and overridable: set `TRANSCRIPT_<HARNESS>_RESUME_CMD` to a `{id}` template, e.g. `TRANSCRIPT_CODEX_RESUME_CMD="codex resume {id}"`.
 
 `view` prints the session as compact text, each message numbered by a `── #N ──` rule. `#range` selects messages by those printed ordinals, 1-based and inclusive:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ txcript maps each harness's native transcript format through a typed common mode
 
 ## Highlights
 
-- **11 harnesses, one model**: every format converts through `Transcript<Common>`, so adding a harness connects it to all the others.
+- **12 harnesses, one model**: every format converts through `Transcript<Common>`, so adding a harness connects it to all the others.
 - **A format for everyone else**: agents txcript has never heard of emit the documented [Simple](docs/formats/simple.md) interchange JSON — a file or a stream, handed to txcript directly — and their transcripts continue in any supported harness.
 - **Byte-lossless round-trips**: loading and saving a session in its own format reproduces it exactly.
 - **Continue anywhere**: `txcript continue <id> --with <harness>` rewrites a session into another harness's native format and launches it. The original is never modified.
@@ -69,6 +69,7 @@ flowchart LR
     common <--> grok["Grok CLI"]
     common <--> antigravity["Antigravity"]
     simple["Simple (any agent)"] --> common
+    hermes["Hermes Agent"] --> common
     amp["Amp"] --> common
 ```
 
@@ -84,6 +85,7 @@ Discovery, listing, search, `view`, and native round-trips work for every harnes
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [spec](docs/formats/cursor.md) |
 | [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | JSON session dir | ⇄ | ✓ | [spec](docs/formats/grok.md) |
+| Hermes Agent | `hermes` | `~/.hermes/state.db` | SQLite | → | — <sup>3</sup> | [spec](docs/formats/hermes.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | thread JSON | → | — <sup>1</sup> | [spec](docs/formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [spec](docs/formats/antigravity.md) |
 | Simple | `simple` | — <sup>2</sup> | interchange JSON | → | — <sup>2</sup> | [spec](docs/formats/simple.md) |
@@ -91,6 +93,8 @@ Discovery, listing, search, `view`, and native round-trips work for every harnes
 <sup>1</sup> Amp threads are server-side and the CLI has no import: sessions convert *from* Amp, but can't be continued into it.
 
 <sup>2</sup> Simple is txcript's own interchange format — the on-ramp for any agent not listed above. There is no app and no managed directory: a Simple session is a document (a file, or stdin) handed to `txcript continue` directly, and the continued conversation lives in the target harness from then on.
+
+<sup>3</sup> Hermes's `state.db` is read-only in txcript and Hermes has no session-import command: sessions convert *from* Hermes, but can't be continued into it.
 
 ## Install
 
@@ -271,7 +275,7 @@ writeFileSync("session.jsonl", convert(input, "codex", "claude_code"));
 const common = JSON.parse(toCommon(input, "codex"));   // { meta, messages }
 const pi = fromCommon(JSON.stringify(common), "pi");
 
-harnesses(); // ["claude_code","codex","opencode","pi","campfire","cursor","cursor_desktop","grok","amp","antigravity","simple"]
+harnesses(); // ["claude_code","codex","opencode","pi","campfire","cursor","cursor_desktop","grok","hermes","amp","antigravity","simple"]
 ```
 
 Text-in / text-out: `input` is the source harness's native session text and the result is the target's. Invalid harness names or unparseable input throw a JS `Error`.
@@ -283,6 +287,7 @@ Text-in / text-out: `input` is the source harness's native session text and the 
 | `cursor` | JSON export of the session's `store.db` |
 | `cursor_desktop` | JSON dump of the session's `state.vscdb` rows |
 | `grok` | JSON bundle of the session directory's files |
+| `hermes` | `hermes sessions export` JSON object |
 | `amp` | `amp threads export` JSON |
 | `antigravity` | JSON dump of the conversation database, protobuf blobs hex-encoded |
 | `simple` | the [Simple](docs/formats/simple.md) interchange JSON document |

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,5 +29,8 @@ txcript = { version = "0.7.0", path = "..", features = ["opencode", "search"] }
 # v7 for codex rollouts, v4 for every other harness — see `fresh_identity`.
 uuid = { version = "1.23.4", features = ["v4", "v7"] }
 
+[dev-dependencies]
+tempfile = "3.27.0"
+
 [lints]
 workspace = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -845,25 +845,32 @@ enum DocInput {
 }
 
 /// Recognize a document argument. `-` is stdin; an argument (or its part
-/// before a `#range` suffix) naming an existing file is that file. A whole
-/// argument that is an existing file wins over the range interpretation, so
-/// a filename containing `#` still opens. Everything else is a session
-/// reference for the discovery path.
+/// before a `#range` suffix) naming an existing readable path is that
+/// document. A whole argument that names one wins over the range
+/// interpretation, so a filename containing `#` still opens. Everything
+/// else is a session reference for the discovery path.
 fn document_source(input: &str) -> Option<(DocInput, Option<fragment::SpanReq>)> {
     if input == "-" {
         return Some((DocInput::Stdin, None));
     }
-    if std::path::Path::new(input).is_file() {
+    if readable_document(input) {
         return Some((DocInput::File(PathBuf::from(input)), None));
     }
     let (src, request) = fragment::parse_ref(input);
     if src == "-" {
         return Some((DocInput::Stdin, request));
     }
-    if std::path::Path::new(src).is_file() {
+    if readable_document(src) {
         return Some((DocInput::File(PathBuf::from(src)), request));
     }
     None
+}
+
+/// Anything openable that isn't a directory: regular files, and the pipes
+/// behind process substitution (`<(my-agent --dump)` arrives as
+/// `/dev/fd/N`, a FIFO — `is_file()` alone would refuse it).
+fn readable_document(path: &str) -> bool {
+    std::fs::metadata(path).is_ok_and(|m| !m.is_dir())
 }
 
 /// Continue a Simple document into `--with`: parse, convert, write into the
@@ -892,9 +899,11 @@ fn continue_document(
             std::fs::read_to_string(path).map_err(|e| format!("reading {}: {e}", path.display()))?
         }
     };
+    // Only a real file's stem is a meaningful identity; a process
+    // substitution's `/dev/fd/N` would leak "N" as the session id.
     let origin = match input {
         DocInput::Stdin => None,
-        DocInput::File(path) => Some(path.as_path()),
+        DocInput::File(path) => Some(path.as_path()).filter(|p| p.is_file()),
     };
     let common = document_to_common(&text, origin)?;
 
@@ -986,6 +995,24 @@ mod document_tests {
             document_source(&ranged),
             Some((DocInput::File(p), Some(_))) if p == plain
         ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_named_pipe_is_a_document_like_process_substitution_provides() {
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("fd-like");
+        let made = std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .unwrap();
+        assert!(made.success());
+        assert!(matches!(
+            document_source(fifo.to_str().unwrap()),
+            Some((DocInput::File(p), None)) if p == fifo
+        ));
+        // A directory is never a document.
+        assert!(document_source(dir.path().to_str().unwrap()).is_none());
     }
 
     #[test]
@@ -1185,42 +1212,55 @@ fn launch_via(
     stdin_tty: bool,
 ) -> Result<ExitCode, String> {
     let (bin, args) = local::resume_command(target, resume_id);
-    if resume {
-        // Hand the terminal to the harness — replaces this process on Unix.
-        let workdir = resume_workdir(cwd);
-        // The id inside the command came from a session file; scrub it for
-        // display (the exec below still gets the exact argv).
-        let shown = style::scrub(
-            &std::iter::once(&bin)
-                .chain(&args)
-                .map(String::as_str)
-                .collect::<Vec<_>>()
-                .join(" "),
-        );
-        match &workdir {
-            Some(dir) => eprintln!(
-                "resuming: {shown} {}",
-                style::dim(&format!("(in {})", dir.display()), style::enabled_err())
-            ),
-            None => eprintln!("resuming: {shown}"),
-        }
-        // Brief pause so users can read or cancel before exec.
-        if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
-            std::thread::sleep(std::time::Duration::from_millis(600));
-        }
-        handoff(
-            &bin,
-            &args,
-            workdir.as_deref(),
-            stdin_tty.then(tty_stdin).flatten(),
-        )
-    } else {
-        println!(
-            "  resume with: {}",
-            style::scrub(&format!("{} {}", bin, args.join(" ")))
-        );
-        Ok(ExitCode::SUCCESS)
+    if !resume {
+        return print_resume_command(&bin, &args);
     }
+    // The session document consumed stdin; the harness needs the controlling
+    // terminal instead — the same reclaim less and fzf do at the end of a
+    // pipeline. Without one (truly headless), exec'ing an interactive
+    // harness onto the spent pipe would just hang it: print the command.
+    let stdin = if stdin_tty {
+        let Some(tty) = tty_stdin() else {
+            eprintln!("stdin carried the session document and no terminal is available");
+            return print_resume_command(&bin, &args);
+        };
+        Some(tty)
+    } else {
+        None
+    };
+    // Hand the terminal to the harness — replaces this process on Unix.
+    let workdir = resume_workdir(cwd);
+    // The id inside the command came from a session file; scrub it for
+    // display (the exec below still gets the exact argv).
+    let shown = style::scrub(
+        &std::iter::once(&bin)
+            .chain(&args)
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(" "),
+    );
+    match &workdir {
+        Some(dir) => eprintln!(
+            "resuming: {shown} {}",
+            style::dim(&format!("(in {})", dir.display()), style::enabled_err())
+        ),
+        None => eprintln!("resuming: {shown}"),
+    }
+    // Brief pause so users can read or cancel before exec.
+    if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        std::thread::sleep(std::time::Duration::from_millis(600));
+    }
+    handoff(&bin, &args, workdir.as_deref(), stdin)
+}
+
+// Result-shaped to slot into `launch_via`'s return paths.
+#[allow(clippy::unnecessary_wraps)]
+fn print_resume_command(bin: &str, args: &[String]) -> Result<ExitCode, String> {
+    println!(
+        "  resume with: {}",
+        style::scrub(&format!("{} {}", bin, args.join(" ")))
+    );
+    Ok(ExitCode::SUCCESS)
 }
 
 /// Return the recorded cwd if it exists; otherwise warn and use the current
@@ -1272,12 +1312,17 @@ fn handoff(
     Err(format!("failed to launch `{bin}`: {e} (is it on PATH?)"))
 }
 
-/// The controlling terminal's input stream, if there is one. `None` (in a
-/// truly headless run) leaves the exhausted pipe in place, which the
-/// harness will see as EOF — the honest signal available.
+/// The controlling terminal, opened the way a shell hands it to an
+/// interactive program: read *and* write. A read-only fd passes `isatty()`
+/// but is not the conventional shape, and TUIs can treat it as
+/// non-interactive. `None` when the process has no controlling terminal.
 fn tty_stdin() -> Option<std::fs::File> {
     let device = if cfg!(windows) { "CONIN$" } else { "/dev/tty" };
-    std::fs::File::open(device).ok()
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(device)
+        .ok()
 }
 
 #[cfg(not(unix))]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1287,24 +1287,27 @@ fn handoff(
     workdir: Option<&std::path::Path>,
     stdin: Option<std::fs::File>,
 ) -> Result<ExitCode, String> {
-    let spawn = |program: &str| {
+    // The `.cmd` retry below needs its own handle; take it before the first
+    // spawn consumes `stdin`.
+    let retry_stdin = stdin.as_ref().and_then(|f| f.try_clone().ok());
+    let spawn = |program: &str, stdin: Option<std::fs::File>| {
         let mut cmd = std::process::Command::new(program);
         cmd.args(args);
         if let Some(dir) = workdir {
             cmd.current_dir(dir);
         }
-        if let Some(stdin) = stdin.as_ref().and_then(|f| f.try_clone().ok()) {
+        if let Some(stdin) = stdin {
             cmd.stdin(stdin);
         }
         cmd.status()
     };
-    let status = match spawn(bin) {
+    let status = match spawn(bin, stdin) {
         Ok(status) => status,
         // npm-installed harnesses are `.cmd` shims on Windows, which
         // CreateProcess won't resolve from the bare name; the explicit
         // extension makes std route the launch through cmd.exe.
         Err(e) if cfg!(windows) && e.kind() == std::io::ErrorKind::NotFound => {
-            spawn(&format!("{bin}.cmd"))
+            spawn(&format!("{bin}.cmd"), retry_stdin)
                 .map_err(|_| format!("failed to launch `{bin}`: {e} (is it on PATH?)"))?
         }
         Err(e) => return Err(format!("failed to launch `{bin}`: {e} (is it on PATH?)")),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1313,16 +1313,71 @@ fn handoff(
 }
 
 /// The controlling terminal, opened the way a shell hands it to an
-/// interactive program: read *and* write. A read-only fd passes `isatty()`
-/// but is not the conventional shape, and TUIs can treat it as
-/// non-interactive. `None` when the process has no controlling terminal.
+/// interactive program: read *and* write, and — crucially — by its *real*
+/// device path, not the `/dev/tty` alias. On macOS, kqueue cannot monitor
+/// the alias device: a TUI handed `/dev/tty` as stdin renders but never
+/// receives keys (Node's libuv has a `select()` workaround; Bun-compiled
+/// TUIs like Claude Code do not). The real device is found the way fzf's
+/// `ttyname()` does: stderr usually still points at the terminal in a
+/// pipeline, so match its device id against `/dev`. `None` when the
+/// process has no controlling terminal.
+#[cfg(unix)]
 fn tty_stdin() -> Option<std::fs::File> {
-    let device = if cfg!(windows) { "CONIN$" } else { "/dev/tty" };
+    let open_rw = |path: &std::path::Path| {
+        std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .ok()
+    };
+    resolved_tty_path()
+        .as_deref()
+        .and_then(open_rw)
+        .or_else(|| open_rw(std::path::Path::new("/dev/tty")))
+}
+
+#[cfg(windows)]
+fn tty_stdin() -> Option<std::fs::File> {
     std::fs::OpenOptions::new()
         .read(true)
         .write(true)
-        .open(device)
+        .open("CONIN$")
         .ok()
+}
+
+/// The real device path of the terminal on stderr (or stdout): fstat the
+/// stream, then scan `/dev/pts/` (Linux) and `/dev/` for the character
+/// device with the same device id. `None` when neither stream is a
+/// terminal or nothing in `/dev` matches.
+#[cfg(unix)]
+fn resolved_tty_path() -> Option<PathBuf> {
+    use std::io::IsTerminal;
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+    let stream_rdev = |fd: i32, terminal: bool| {
+        terminal
+            .then(|| std::fs::metadata(format!("/dev/fd/{fd}")).ok())
+            .flatten()
+            .map(|m| m.rdev())
+    };
+    let rdev = stream_rdev(2, std::io::stderr().is_terminal())
+        .or_else(|| stream_rdev(1, std::io::stdout().is_terminal()))?;
+
+    for dir in ["/dev/pts", "/dev"] {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if let Ok(meta) = entry.metadata()
+                && meta.file_type().is_char_device()
+                && meta.rdev() == rdev
+                && entry.path() != std::path::Path::new("/dev/tty")
+            {
+                return Some(entry.path());
+            }
+        }
+    }
+    None
 }
 
 #[cfg(not(unix))]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -52,8 +52,8 @@ mod fragment;
 mod mcp;
 mod view;
 
-const HARNESSES: &str = "harnesses: claude_code, codex, opencode, pi, campfire, cursor, cursor_desktop, grok, amp, \
-     antigravity, simple";
+const HARNESSES: &str = "harnesses: claude_code, codex, opencode, pi, campfire, cursor, cursor_desktop, grok, hermes, \
+     amp, antigravity, simple";
 
 #[derive(Parser)]
 #[command(
@@ -755,6 +755,7 @@ mod style {
             HarnessId::Cursor => "\x1b[34m",        // blue
             HarnessId::CursorDesktop => "\x1b[96m", // bright cyan
             HarnessId::Grok => "\x1b[37m",          // white
+            HarnessId::Hermes => "\x1b[93m",        // bright yellow
             HarnessId::Amp => "\x1b[95m",           // bright magenta
             HarnessId::Antigravity => "\x1b[94m",   // bright blue
             HarnessId::Simple => "\x1b[92m",        // bright green

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,6 +12,9 @@
 //!     [--from <harness>]                    #   scope the id lookup to one harness
 //!     [--out <dir>]                         #   write under <dir>; implies --no-resume
 //!     [--no-resume]                         #   write the session but don't launch
+//! txcript continue <file|->[#range]     # continue a Simple document (file, or stdin
+//!     --with <harness> [...]                #   for `-`) into <harness>; see
+//!                                           #   docs/formats/simple.md
 //! txcript view <id>[#range]             # print a session as compact text
 //!     [--from <harness>]                    #   scope the id lookup to one harness
 //! txcript query '<pattern>'             # one-shot search, print ranked hits
@@ -42,7 +45,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::{CommandFactory, Parser, Subcommand};
-use txcript::harness::amp;
+use txcript::harness::{amp, simple};
 use txcript::{Codec, Common, HarnessId, TextCodec, Transcript, local};
 
 mod fragment;
@@ -93,13 +96,19 @@ enum Command {
     /// A `#range` suffix continues just those messages (as a new session);
     /// ranges that cut a tool call away from its result are refused.
     ///
+    /// The argument may also be a Simple interchange document — a file
+    /// path, or `-` for stdin — instead of a local session: any agent's
+    /// transcript in the format of docs/formats/simple.md continues into
+    /// the harness named by --with (required for documents).
+    ///
     /// Anything that writes a copy writes a *new* session, with its own id and
     /// today's timestamp — the source is never modified. The printed resume
     /// command carries the new id.
     Continue {
-        /// Session id (any unambiguous prefix) or its exact title, with an
-        /// optional `#range` of 1-based inclusive message numbers
-        /// (`abc#5-12`, `#7`, `#5-`, `#-10`)
+        /// Session id (any unambiguous prefix) or its exact title; or a
+        /// Simple document (a file path, `-` for stdin). Takes an optional
+        /// `#range` of 1-based inclusive message numbers (`abc#5-12`, `#7`,
+        /// `#5-`, `#-10`)
         // Other: without a hint, generated completions fall back to filenames.
         #[arg(value_hint = clap::ValueHint::Other)]
         id: String,
@@ -760,6 +769,27 @@ fn cmd_continue(
     out: Option<&PathBuf>,
     no_resume: bool,
 ) -> Result<ExitCode, String> {
+    // A Simple interchange document (stdin, or an existing file) rather than
+    // a local session id. Checked before discovery: the document names its
+    // input directly, so no session can shadow it.
+    if let Some((input, request)) = document_source(id) {
+        if from.is_some() {
+            return Err(
+                "--from scopes the search for a local session; a Simple document \
+                 is its own input and takes --with only"
+                    .to_string(),
+            );
+        }
+        let resume = out.is_none() && !no_resume;
+        return continue_document(
+            &input,
+            request.as_ref(),
+            with,
+            out.map(PathBuf::as_path),
+            resume,
+        );
+    }
+
     // Locate the session by id (exact or unambiguous prefix) or exact title,
     // optionally scoped to one harness.
     let sessions = discover_with_spinner();
@@ -796,8 +826,179 @@ fn cmd_continue(
         }
         None => Err(match from {
             Some(h) => format!("no {h} session matches `{src}` (try `txcript list`)"),
+            // A path-looking argument that named no file falls through to the
+            // session lookup; say so, or the "no session" alone misleads.
+            None if src.contains(['/', '\\']) => format!(
+                "no local session matches `{src}`, and no such file exists \
+                 (a Simple document must be an existing file, or `-` for stdin)"
+            ),
             None => format!("no local session matches `{src}` (try `txcript list`)"),
         }),
+    }
+}
+
+/// What `continue` received when it wasn't a session id: a Simple document
+/// on stdin or in a file.
+enum DocInput {
+    Stdin,
+    File(PathBuf),
+}
+
+/// Recognize a document argument. `-` is stdin; an argument (or its part
+/// before a `#range` suffix) naming an existing file is that file. A whole
+/// argument that is an existing file wins over the range interpretation, so
+/// a filename containing `#` still opens. Everything else is a session
+/// reference for the discovery path.
+fn document_source(input: &str) -> Option<(DocInput, Option<fragment::SpanReq>)> {
+    if input == "-" {
+        return Some((DocInput::Stdin, None));
+    }
+    if std::path::Path::new(input).is_file() {
+        return Some((DocInput::File(PathBuf::from(input)), None));
+    }
+    let (src, request) = fragment::parse_ref(input);
+    if src == "-" {
+        return Some((DocInput::Stdin, request));
+    }
+    if std::path::Path::new(src).is_file() {
+        return Some((DocInput::File(PathBuf::from(src)), request));
+    }
+    None
+}
+
+/// Continue a Simple document into `--with`: parse, convert, write into the
+/// target's store, launch. The document is read once and never modified;
+/// from here on the conversation lives in the target harness.
+fn continue_document(
+    input: &DocInput,
+    span_req: Option<&fragment::SpanReq>,
+    with: Option<HarnessId>,
+    out: Option<&std::path::Path>,
+    resume: bool,
+) -> Result<ExitCode, String> {
+    let target = with.ok_or_else(|| {
+        "a Simple document has no harness of its own to resume; \
+         pass --with <harness> (e.g. --with claude_code)"
+            .to_string()
+    })?;
+    let text = match input {
+        DocInput::Stdin => {
+            let mut buffer = String::new();
+            std::io::Read::read_to_string(&mut std::io::stdin(), &mut buffer)
+                .map_err(|e| format!("reading stdin: {e}"))?;
+            buffer
+        }
+        DocInput::File(path) => {
+            std::fs::read_to_string(path).map_err(|e| format!("reading {}: {e}", path.display()))?
+        }
+    };
+    let origin = match input {
+        DocInput::Stdin => None,
+        DocInput::File(path) => Some(path.as_path()),
+    };
+    let common = document_to_common(&text, origin)?;
+
+    let mut copy = match span_req {
+        Some(req) => fragment::sliced(&common, req)?,
+        None => common,
+    };
+    fresh_identity(&mut copy, target, out);
+    if copy.meta.id.is_empty() {
+        // An `--out` export keeps the source identity — which stdin may not
+        // carry at all. The target store still needs a file name.
+        copy.meta.id = uuid::Uuid::new_v4().to_string();
+    }
+    // A document without a recorded cwd continues *here*: the target stores
+    // shard by cwd, and "the directory the user ran txcript in" is the only
+    // sensible home for a transcript that never had one.
+    if out.is_none()
+        && copy.meta.cwd.as_deref().unwrap_or("").is_empty()
+        && let Ok(current) = std::env::current_dir()
+    {
+        copy.meta.cwd = Some(current.to_string_lossy().into_owned());
+    }
+    stamp_live_cwd(&mut copy, out);
+    let resume_id = write_and_report(HarnessId::Simple, target, &copy, out)?;
+    // Stdin was consumed by the document; hand the launched harness the
+    // terminal instead, or an interactive resume would read EOF.
+    let stdin_tty = matches!(input, DocInput::Stdin);
+    launch_via(
+        target,
+        &resume_id,
+        copy.meta.cwd.as_deref(),
+        resume,
+        stdin_tty,
+    )
+}
+
+/// Parse a Simple document into the canonical model, backfilling an empty id
+/// from the file stem (the same fallback the file-backed stores use).
+fn document_to_common(
+    text: &str,
+    origin: Option<&std::path::Path>,
+) -> Result<Transcript<Common>, String> {
+    let native = simple::Simple::from_text(text).map_err(|e| e.to_string())?;
+    let mut common = simple::Simple::to_common(&native).map_err(|e| e.to_string())?;
+    if common.meta.id.is_empty()
+        && let Some(stem) = origin.and_then(|p| p.file_stem())
+    {
+        common.meta.id = stem.to_string_lossy().into_owned();
+    }
+    Ok(common)
+}
+
+#[cfg(test)]
+mod document_tests {
+    use super::{DocInput, document_source, document_to_common};
+
+    #[test]
+    fn dash_is_stdin_and_session_references_are_not_documents() {
+        assert!(matches!(
+            document_source("-"),
+            Some((DocInput::Stdin, None))
+        ));
+        assert!(matches!(
+            document_source("-#1-3"),
+            Some((DocInput::Stdin, Some(_)))
+        ));
+        assert!(document_source("a57bc87d").is_none());
+        assert!(document_source("Fix the parser").is_none());
+        // A path spelling that names no file is not a document either; the
+        // session lookup owns the error message.
+        assert!(document_source("./no/such/file.json").is_none());
+    }
+
+    #[test]
+    fn an_existing_file_wins_over_the_range_interpretation() {
+        let dir = tempfile::tempdir().unwrap();
+        let hashed = dir.path().join("notes#5.json");
+        std::fs::write(&hashed, "{}").unwrap();
+        // The whole argument names a real file: no range is split off.
+        assert!(matches!(
+            document_source(hashed.to_str().unwrap()),
+            Some((DocInput::File(p), None)) if p == hashed
+        ));
+
+        let plain = dir.path().join("run.json");
+        std::fs::write(&plain, "{}").unwrap();
+        let ranged = format!("{}#1-2", plain.display());
+        assert!(matches!(
+            document_source(&ranged),
+            Some((DocInput::File(p), Some(_))) if p == plain
+        ));
+    }
+
+    #[test]
+    fn an_empty_document_id_falls_back_to_the_file_stem() {
+        let text = r#"{"messages": [{"role": "user", "content": "hi"}]}"#;
+        let from_file = document_to_common(
+            text,
+            Some(std::path::Path::new("/anywhere/dropped-here.json")),
+        )
+        .unwrap();
+        assert_eq!(from_file.meta.id, "dropped-here");
+        // Stdin has no name to borrow; the id stays empty for the caller.
+        assert_eq!(document_to_common(text, None).unwrap().meta.id, "");
     }
 }
 
@@ -970,6 +1171,19 @@ fn launch(
     cwd: Option<&str>,
     resume: bool,
 ) -> Result<ExitCode, String> {
+    launch_via(target, resume_id, cwd, resume, false)
+}
+
+/// [`launch`], optionally reattaching the controlling terminal as the
+/// harness's stdin — needed when the session document was itself read from
+/// stdin, which an interactive resume would otherwise find at EOF.
+fn launch_via(
+    target: HarnessId,
+    resume_id: &str,
+    cwd: Option<&str>,
+    resume: bool,
+    stdin_tty: bool,
+) -> Result<ExitCode, String> {
     let (bin, args) = local::resume_command(target, resume_id);
     if resume {
         // Hand the terminal to the harness — replaces this process on Unix.
@@ -994,7 +1208,12 @@ fn launch(
         if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
             std::thread::sleep(std::time::Duration::from_millis(600));
         }
-        handoff(&bin, &args, workdir.as_deref())
+        handoff(
+            &bin,
+            &args,
+            workdir.as_deref(),
+            stdin_tty.then(tty_stdin).flatten(),
+        )
     } else {
         println!(
             "  resume with: {}",
@@ -1037,6 +1256,7 @@ fn handoff(
     bin: &str,
     args: &[String],
     workdir: Option<&std::path::Path>,
+    stdin: Option<std::fs::File>,
 ) -> Result<ExitCode, String> {
     use std::os::unix::process::CommandExt;
     let mut cmd = std::process::Command::new(bin);
@@ -1044,9 +1264,20 @@ fn handoff(
     if let Some(dir) = workdir {
         cmd.current_dir(dir);
     }
+    if let Some(stdin) = stdin {
+        cmd.stdin(stdin);
+    }
     // `exec` only returns if it failed to launch.
     let e = cmd.exec();
     Err(format!("failed to launch `{bin}`: {e} (is it on PATH?)"))
+}
+
+/// The controlling terminal's input stream, if there is one. `None` (in a
+/// truly headless run) leaves the exhausted pipe in place, which the
+/// harness will see as EOF — the honest signal available.
+fn tty_stdin() -> Option<std::fs::File> {
+    let device = if cfg!(windows) { "CONIN$" } else { "/dev/tty" };
+    std::fs::File::open(device).ok()
 }
 
 #[cfg(not(unix))]
@@ -1054,12 +1285,16 @@ fn handoff(
     bin: &str,
     args: &[String],
     workdir: Option<&std::path::Path>,
+    stdin: Option<std::fs::File>,
 ) -> Result<ExitCode, String> {
     let spawn = |program: &str| {
         let mut cmd = std::process::Command::new(program);
         cmd.args(args);
         if let Some(dir) = workdir {
             cmd.current_dir(dir);
+        }
+        if let Some(stdin) = stdin.as_ref().and_then(|f| f.try_clone().ok()) {
+            cmd.stdin(stdin);
         }
         cmd.status()
     };

--- a/docs/formats/README.md
+++ b/docs/formats/README.md
@@ -45,6 +45,7 @@ than none.
 | [cursor.md](cursor.md) | Cursor | `src/harness/cursor.rs` |
 | [amp.md](amp.md) | Amp (Sourcegraph) | `src/harness/amp.rs` |
 | [grok.md](grok.md) | Grok CLI (xAI) | `src/harness/grok.rs` |
+| [hermes.md](hermes.md) | Hermes Agent | `src/harness/hermes.rs` |
 | [antigravity.md](antigravity.md) | Antigravity (Google) | `src/harness/antigravity.rs` |
 | [pi.md](pi.md) | pi | `src/harness/pi.rs` |
 | [campfire.md](campfire.md) | Campfire (embeds pi) | `src/harness/campfire.rs` |

--- a/docs/formats/hermes.md
+++ b/docs/formats/hermes.md
@@ -1,0 +1,79 @@
+# Hermes Agent
+
+Hermes Agent keeps its sessions in a single `SQLite` database,
+`~/.hermes/state.db`, and ships a `hermes sessions export` command that
+emits one JSON object per session. That export object — the session row
+with its message rows nested in a `messages` array — is the harness's
+portable text form; txcript reads the database directly for discovery and
+loading, matching the exporter's semantics. Provenance is
+**reverse-engineered**: the format was described from observed sessions and
+Hermes's storage behavior (Hermes CLI, July 2026), cross-checked against
+txcript's parser in `src/harness/hermes.rs`.
+
+```
+~/.hermes/state.db                       ($HERMES_HOME/state.db overrides)
+├─ sessions                              one row per session
+│    id, source, model, started_at,      metadata; archived=1 rows are
+│    cwd, git_branch, title, archived    hidden from discovery
+└─ messages                              ordered rows per session
+     role: user | assistant | tool       conversation
+     role: session_meta, …               bookkeeping, carried not converted
+```
+
+## On disk
+
+The database resolves as `$HERMES_HOME/state.db` (when set and non-empty),
+else `~/.hermes/state.db`. Discovery lists non-archived `sessions` rows;
+loading selects the session's `messages` rows `WHERE active = 1 ORDER BY
+id`, mirroring the exporter: rewound rows (`active = 0`) are history Hermes
+itself no longer replays, and stay out.
+
+The store is deliberately **read-only** (`SQLITE_OPEN_READ_ONLY`): Hermes
+has no supported session-import API, so txcript converts sessions *from*
+Hermes but never writes into `state.db`. `save` and `delete` refuse;
+continuing *into* Hermes is refused at the conversion layer with the same
+explanation.
+
+## Dissection of a transcript
+
+| Their name | What it is | Maps to |
+|---|---|---|
+| `sessions` row | `id`, `model`, `started_at` (epoch seconds, float), `cwd`, `git_branch`, `title` | `Meta` |
+| `messages` / role `user` | `content`: string, or structured parts (decoded from the `\0json:` sentinel prefix) | `Role::User` with `Block::Text` / `Block::Image` (data-URL `image_url` parts) |
+| `messages` / role `assistant` | `content`, `tool_calls` (OpenAI function-call shape), `reasoning_content`, `codex_reasoning_items`, `finish_reason` | `Role::Assistant`; `Block::Thinking` (opaque reasoning in `encrypted`), `Block::ToolUse`, `Message.stop_reason` |
+| `messages` / role `tool` | `content`, `tool_call_id`, `effect_disposition` | `Role::User` with `Block::ToolResult`; `denied` → `is_error` |
+| `messages` / other roles | `session_meta` and future bookkeeping | carried in the native body, no conversational turn |
+
+Tool names normalize to the Claude convention and back: `read_file` /
+`write_file` ⇄ `Read`/`Write` (`path` ⇄ `file_path`), `patch` with
+`mode: "replace"` ⇄ `Edit`, `terminal` ⇄ `Bash` (`background` ⇄
+`run_in_background`, `timeout` seconds ⇄ `timeout_ms`). Unknown names and
+malformed argument JSON pass through as `Tool::Raw`. Tool-result strings
+that parse as JSON objects/arrays become structured output; error status is
+inferred from `effect_disposition: "denied"`, `success: false`, a non-zero
+`exit_code`, or a non-null `error`.
+
+The native export JSON is retained as an opaque value, so unknown session
+columns, message columns, and bookkeeping roles survive text round trips.
+
+## Caveats
+
+- Read-only by design (no import API); `--with hermes` is refused.
+- Multiple same-kind reasoning blocks join with newlines on write; images
+  have no native message-row slot outside structured content parts.
+- `started_at` missing or malformed parses to the Unix epoch,
+  deterministically, rather than the current time — discovery order stays
+  stable for a database txcript cannot fully interpret.
+- Blob columns (none in the known schema) would surface as
+  `{"$blob_hex": …}` values.
+
+## References
+
+No vendor format documentation is published. The parser
+(`src/harness/hermes.rs`) and the integration tests
+(`tests/integration/hermes.rs`, including a real temp `SQLite` database
+matching the observed schema) are the normative mapping. Observed against
+Hermes CLI sessions in July 2026; not re-verified against a live install
+since (none was available at revival time).
+
+Last verified: 2026-07-17 (original observation; revived 2026-08-18).

--- a/src/harness/hermes.rs
+++ b/src/harness/hermes.rs
@@ -1,0 +1,862 @@
+//! Hermes Agent sessions: `~/.hermes/state.db` and `hermes sessions export`.
+//!
+//! Hermes stores session metadata and ordered message rows in `SQLite`. Its JSONL
+//! exporter emits one JSON object per session, with the message rows nested in
+//! a `messages` array; that object is this harness's portable text form. The
+//! codec reads active user, assistant, and tool rows, preserving reasoning,
+//! function calls, results, stop reasons, and metadata through [`Common`].
+//!
+//! Native JSON is retained as an opaque [`Value`], so unknown session columns,
+//! message columns, and bookkeeping roles survive text round trips. Hermes has
+//! no public import command, so the store is intentionally read-only; generated
+//! Hermes text can be exported or converted, but is not inserted into a live
+//! `state.db`. Multiple same-kind text/reasoning blocks are joined with newlines,
+//! and images have no native Hermes message-row slot.
+
+use chrono::{DateTime, Utc};
+use serde_json::{Map, Value, json};
+use uuid::Uuid;
+
+#[cfg(feature = "hermes")]
+use rusqlite::{Connection, OpenFlags};
+#[cfg(feature = "hermes")]
+use std::collections::HashMap;
+#[cfg(feature = "hermes")]
+use std::path::Path;
+use std::path::PathBuf;
+
+use crate::common::{Block, ImageSource, Message, Meta, Role, StopReason, Tool, ToolOutput};
+use crate::error::{Error, Result};
+use crate::transcript::{Codec, Common, Discovered, Harness, Saved, Store, TextCodec, Transcript};
+
+/// The Hermes Agent harness marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Hermes;
+
+impl Harness for Hermes {
+    const NAME: &'static str = "hermes";
+    type Body = Value;
+}
+
+impl TextCodec for Hermes {
+    fn from_text(text: &str) -> Result<Transcript<Self>> {
+        let body: Value = serde_json::from_str(text)?;
+        let meta = meta_from_export(&body);
+        Ok(Transcript::new(meta, body))
+    }
+
+    fn to_text(transcript: &Transcript<Self>) -> Result<String> {
+        Ok(serde_json::to_string_pretty(&transcript.body)?)
+    }
+}
+
+impl Codec for Hermes {
+    fn to_common(transcript: &Transcript<Self>) -> Result<Transcript<Common>> {
+        Ok(Transcript::new(
+            transcript.meta.clone(),
+            messages_from_export(&transcript.body, &transcript.meta),
+        ))
+    }
+
+    fn from_common(transcript: &Transcript<Common>) -> Result<Transcript<Self>> {
+        let body = export_from_messages(&transcript.meta, &transcript.body);
+        let mut meta = transcript.meta.clone();
+        if meta.id.is_empty() {
+            meta.id = body
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+        }
+        Ok(Transcript::new(meta, body))
+    }
+}
+
+/// Read-only access to Hermes Agent's canonical `state.db` session store.
+#[derive(Debug, Clone)]
+pub struct HermesStore {
+    pub db_path: PathBuf,
+}
+
+impl HermesStore {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            db_path: path.into(),
+        }
+    }
+
+    /// Resolve `$HERMES_HOME/state.db`, falling back to `~/.hermes/state.db`.
+    #[must_use]
+    pub fn default_root() -> Option<Self> {
+        std::env::var_os("HERMES_HOME")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .or_else(|| super::home_dir().map(|home| home.join(".hermes")))
+            .map(|root| Self::new(root.join("state.db")))
+    }
+}
+
+#[cfg(feature = "hermes")]
+impl Store for HermesStore {
+    type H = Hermes;
+    type Ref = String;
+
+    fn discover(&self) -> Result<Vec<Discovered<String>>> {
+        if !self.db_path.is_file() {
+            return Ok(Vec::new());
+        }
+        let conn = open_read_only(&self.db_path)?;
+        let rows = query_rows(&conn, "SELECT * FROM sessions", &[])?;
+        Ok(rows
+            .into_iter()
+            .filter(|row| row.get("archived").and_then(Value::as_i64) != Some(1))
+            .filter_map(|row| {
+                let body = Value::Object(row);
+                let meta = meta_from_export(&body);
+                (!meta.id.is_empty()).then(|| Discovered {
+                    reference: meta.id.clone(),
+                    meta,
+                })
+            })
+            .collect())
+    }
+
+    fn load(&self, reference: &String) -> Result<Transcript<Hermes>> {
+        let conn = open_read_only(&self.db_path)?;
+        let mut sessions = query_rows(
+            &conn,
+            "SELECT * FROM sessions WHERE id = ?1",
+            &[reference.as_str()],
+        )?;
+        let mut session = sessions.pop().ok_or_else(|| Error::Malformed {
+            harness: Hermes::NAME,
+            detail: format!(
+                "session `{reference}` not found in {}",
+                self.db_path.display()
+            ),
+        })?;
+        let mut messages = query_rows(
+            &conn,
+            "SELECT * FROM messages WHERE session_id = ?1 AND active = 1 ORDER BY id",
+            &[reference.as_str()],
+        )?;
+        for row in &mut messages {
+            normalize_export_message(row);
+        }
+        session.insert(
+            "messages".to_string(),
+            Value::Array(messages.into_iter().map(Value::Object).collect()),
+        );
+        let body = Value::Object(session);
+        Ok(Transcript::new(meta_from_export(&body), body))
+    }
+
+    fn save(&self, _transcript: &Transcript<Hermes>) -> Result<Saved<String>> {
+        Err(read_only_error())
+    }
+
+    fn delete(&self, _reference: &String) -> Result<()> {
+        Err(read_only_error())
+    }
+
+    fn fingerprints(&self, refs: &[String]) -> Result<HashMap<String, String>> {
+        let mut output = HashMap::with_capacity(refs.len());
+        for reference in refs {
+            let transcript = self.load(reference)?;
+            output.insert(reference.clone(), stable_hash(&transcript.body));
+        }
+        Ok(output)
+    }
+}
+
+#[cfg(not(feature = "hermes"))]
+impl Store for HermesStore {
+    type H = Hermes;
+    type Ref = String;
+
+    fn discover(&self) -> Result<Vec<Discovered<String>>> {
+        Ok(Vec::new())
+    }
+
+    fn load(&self, _reference: &String) -> Result<Transcript<Hermes>> {
+        Err(sqlite_unavailable())
+    }
+
+    fn save(&self, _transcript: &Transcript<Hermes>) -> Result<Saved<String>> {
+        Err(sqlite_unavailable())
+    }
+
+    fn delete(&self, _reference: &String) -> Result<()> {
+        Err(sqlite_unavailable())
+    }
+}
+
+#[cfg(feature = "hermes")]
+fn open_read_only(path: &Path) -> Result<Connection> {
+    Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(sqlite_error)
+}
+
+#[cfg(feature = "hermes")]
+fn query_rows(conn: &Connection, sql: &str, args: &[&str]) -> Result<Vec<Map<String, Value>>> {
+    let mut statement = conn.prepare(sql).map_err(sqlite_error)?;
+    let names: Vec<String> = statement
+        .column_names()
+        .into_iter()
+        .map(String::from)
+        .collect();
+    let mut rows = statement
+        .query(rusqlite::params_from_iter(args.iter()))
+        .map_err(sqlite_error)?;
+    let mut output = Vec::new();
+    while let Some(row) = rows.next().map_err(sqlite_error)? {
+        let mut object = Map::with_capacity(names.len());
+        for (index, name) in names.iter().enumerate() {
+            let value = row.get_ref(index).map_err(sqlite_error)?;
+            object.insert(name.clone(), sqlite_value(value));
+        }
+        output.push(object);
+    }
+    Ok(output)
+}
+
+#[cfg(feature = "hermes")]
+fn sqlite_value(value: rusqlite::types::ValueRef<'_>) -> Value {
+    match value {
+        rusqlite::types::ValueRef::Null => Value::Null,
+        rusqlite::types::ValueRef::Integer(number) => json!(number),
+        rusqlite::types::ValueRef::Real(number) => json!(number),
+        rusqlite::types::ValueRef::Text(bytes) => {
+            Value::String(String::from_utf8_lossy(bytes).into_owned())
+        }
+        rusqlite::types::ValueRef::Blob(bytes) => json!({"$blob_hex": hex(bytes)}),
+    }
+}
+
+#[cfg(feature = "hermes")]
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len().saturating_mul(2));
+    for byte in bytes {
+        output.push(char::from(DIGITS[usize::from(byte >> 4)]));
+        output.push(char::from(DIGITS[usize::from(byte & 0x0f)]));
+    }
+    output
+}
+
+#[cfg(feature = "hermes")]
+fn normalize_export_message(row: &mut Map<String, Value>) {
+    // `HermesState.get_messages` decodes sentinel-prefixed structured content
+    // and tool_calls, while leaving ordinary JSON-looking tool-result strings
+    // as text. Match that public export contract rather than exposing SQLite's
+    // storage representation.
+    if let Some(value) = row.get_mut("content")
+        && let Value::String(content) = value
+        && let Some(encoded) = content.strip_prefix("\0json:")
+        && let Ok(decoded) = serde_json::from_str(encoded)
+    {
+        *value = decoded;
+    }
+    if let Some(value) = row.get_mut("tool_calls")
+        && let Value::String(text) = value
+        && !text.is_empty()
+    {
+        *value = serde_json::from_str(text).unwrap_or_else(|_| json!([]));
+    }
+}
+
+#[cfg(feature = "hermes")]
+#[allow(clippy::needless_pass_by_value)]
+fn sqlite_error(error: rusqlite::Error) -> Error {
+    Error::Malformed {
+        harness: Hermes::NAME,
+        detail: error.to_string(),
+    }
+}
+
+#[cfg(feature = "hermes")]
+fn read_only_error() -> Error {
+    Error::Unconvertible {
+        harness: Hermes::NAME,
+        detail:
+            "Hermes state.db support is read-only; use `hermes sessions export` for portable output"
+                .to_string(),
+    }
+}
+
+#[cfg(not(feature = "hermes"))]
+fn sqlite_unavailable() -> Error {
+    Error::Unconvertible {
+        harness: Hermes::NAME,
+        detail: "Hermes store support requires the `hermes` feature for SQLite".to_string(),
+    }
+}
+
+fn meta_from_export(body: &Value) -> Meta {
+    let string = |key: &str| {
+        body.get(key)
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+    };
+    Meta {
+        id: string("id").unwrap_or_default(),
+        timestamp: body
+            .get("started_at")
+            .and_then(Value::as_f64)
+            .and_then(timestamp_from_seconds)
+            .unwrap_or(DateTime::<Utc>::UNIX_EPOCH),
+        cwd: string("cwd"),
+        git_branch: string("git_branch"),
+        title: string("title"),
+        cli_version: string("cli_version"),
+        model: string("model"),
+    }
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn timestamp_from_seconds(seconds: f64) -> Option<DateTime<Utc>> {
+    if !seconds.is_finite() {
+        return None;
+    }
+    let whole = seconds.floor();
+    let nanos = ((seconds - whole) * 1_000_000_000.0).round();
+    let secs = whole as i64;
+    let nanos = nanos.clamp(0.0, 999_999_999.0) as u32;
+    DateTime::from_timestamp(secs, nanos)
+}
+
+fn message_timestamp(row: &Value, fallback: DateTime<Utc>) -> DateTime<Utc> {
+    row.get("timestamp")
+        .and_then(Value::as_f64)
+        .and_then(timestamp_from_seconds)
+        .unwrap_or(fallback)
+}
+
+fn messages_from_export(body: &Value, meta: &Meta) -> Vec<Message> {
+    body.get("messages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|row| row.get("active").and_then(Value::as_i64) != Some(0))
+        .filter_map(|row| message_from_row(row, meta))
+        .collect()
+}
+
+fn message_from_row(row: &Value, meta: &Meta) -> Option<Message> {
+    let timestamp = message_timestamp(row, meta.timestamp);
+    match row.get("role").and_then(Value::as_str) {
+        Some("user") => {
+            let content = content_blocks(row.get("content"));
+            (!content.is_empty()).then_some(Message {
+                role: Role::User,
+                content,
+                timestamp,
+                model: None,
+                stop_reason: None,
+                usage: None,
+            })
+        }
+        Some("assistant") => assistant_message(row, meta, timestamp),
+        Some("tool") => tool_result_message(row, timestamp),
+        // `session_meta`, system, and future bookkeeping rows remain in the
+        // native body but carry no conversational turn.
+        _ => None,
+    }
+}
+
+fn assistant_message(row: &Value, meta: &Meta, timestamp: DateTime<Utc>) -> Option<Message> {
+    let mut content = Vec::new();
+    let reasoning = reasoning_text(row).filter(|s| !s.trim().is_empty());
+    let encrypted = reasoning_encrypted(row);
+    if reasoning.is_some() || encrypted.is_some() {
+        content.push(Block::Thinking {
+            text: reasoning.unwrap_or_default(),
+            signature: None,
+            encrypted,
+        });
+    }
+    content.extend(content_blocks(row.get("content")));
+    if let Some(calls) = tool_calls(row) {
+        content.extend(calls);
+    }
+    if content.is_empty() {
+        return None;
+    }
+    Some(Message {
+        role: Role::Assistant,
+        content,
+        timestamp,
+        model: meta.model.clone(),
+        stop_reason: row
+            .get("finish_reason")
+            .and_then(Value::as_str)
+            .map(parse_finish_reason),
+        usage: None,
+    })
+}
+
+fn content_blocks(value: Option<&Value>) -> Vec<Block> {
+    match value {
+        None | Some(Value::Null) => Vec::new(),
+        Some(Value::String(text)) if text.trim().is_empty() => Vec::new(),
+        Some(Value::String(text)) => vec![Block::Text { text: text.clone() }],
+        Some(Value::Array(parts)) => parts.iter().filter_map(content_part).collect(),
+        Some(value) => content_part(value).into_iter().collect(),
+    }
+}
+
+fn content_part(part: &Value) -> Option<Block> {
+    match part.get("type").and_then(Value::as_str) {
+        Some("text") => part
+            .get("text")
+            .and_then(Value::as_str)
+            .map(|text| Block::Text {
+                text: text.to_string(),
+            }),
+        Some("image_url") => part
+            .pointer("/image_url/url")
+            .and_then(Value::as_str)
+            .and_then(data_url_image)
+            .or(Some(Block::Text {
+                text: value_text(part),
+            })),
+        _ => Some(Block::Text {
+            text: value_text(part),
+        }),
+    }
+}
+
+fn data_url_image(url: &str) -> Option<Block> {
+    let value = url.strip_prefix("data:")?;
+    let (media_type, data) = value.split_once(";base64,")?;
+    Some(Block::Image {
+        source: ImageSource {
+            source_type: "base64".to_string(),
+            media_type: media_type.to_string(),
+            data: data.to_string(),
+        },
+    })
+}
+
+fn reasoning_text(row: &Value) -> Option<String> {
+    ["reasoning_content", "reasoning"]
+        .into_iter()
+        .find_map(|key| text_content(row.get(key)).filter(|s| !s.is_empty()))
+}
+
+fn reasoning_encrypted(row: &Value) -> Option<String> {
+    ["codex_reasoning_items", "reasoning_details"]
+        .into_iter()
+        .find_map(|key| row.get(key).filter(|v| !v.is_null()))
+        .map(value_text)
+}
+
+fn tool_calls(row: &Value) -> Option<Vec<Block>> {
+    let value = row.get("tool_calls")?;
+    let parsed;
+    let calls = if let Some(array) = value.as_array() {
+        array
+    } else {
+        let text = value.as_str()?;
+        parsed = serde_json::from_str::<Value>(text).ok()?;
+        parsed.as_array()?
+    };
+    Some(calls.iter().filter_map(tool_call_block).collect())
+}
+
+fn tool_call_block(call: &Value) -> Option<Block> {
+    let function = call.get("function")?;
+    let name = function.get("name").and_then(Value::as_str)?;
+    let input = match function.get("arguments") {
+        Some(Value::String(text)) => {
+            serde_json::from_str(text).unwrap_or_else(|_| Value::String(text.clone()))
+        }
+        Some(value) => value.clone(),
+        None => Value::Object(Map::new()),
+    };
+    let id = call
+        .get("id")
+        .or_else(|| call.get("call_id"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let (canonical_name, canonical_input) = normalize_tool(name, input);
+    Some(Block::ToolUse {
+        id,
+        tool: Tool::from_canonical(&canonical_name, canonical_input),
+    })
+}
+
+fn normalize_tool(name: &str, input: Value) -> (String, Value) {
+    let Some(mut object) = input.as_object().cloned() else {
+        return (name.to_string(), input);
+    };
+    match name {
+        "read_file" => {
+            rename_key(&mut object, "path", "file_path");
+            ("Read".to_string(), Value::Object(object))
+        }
+        "write_file" => {
+            rename_key(&mut object, "path", "file_path");
+            ("Write".to_string(), Value::Object(object))
+        }
+        "patch" if object.get("mode").and_then(Value::as_str) == Some("replace") => {
+            object.remove("mode");
+            rename_key(&mut object, "path", "file_path");
+            ("Edit".to_string(), Value::Object(object))
+        }
+        "terminal" => {
+            rename_key(&mut object, "background", "run_in_background");
+            if let Some(timeout) = object.get_mut("timeout")
+                && let Some(seconds) = timeout.as_u64()
+            {
+                *timeout = json!(seconds.saturating_mul(1000));
+                rename_key(&mut object, "timeout", "timeout_ms");
+            }
+            ("Bash".to_string(), Value::Object(object))
+        }
+        _ => (name.to_string(), Value::Object(object)),
+    }
+}
+
+fn rename_key(object: &mut Map<String, Value>, from: &str, to: &str) {
+    if let Some(value) = object.remove(from) {
+        object.insert(to.to_string(), value);
+    }
+}
+
+fn tool_result_message(row: &Value, timestamp: DateTime<Utc>) -> Option<Message> {
+    let tool_use_id = row.get("tool_call_id").and_then(Value::as_str)?.to_string();
+    let content = row
+        .get("content")
+        .cloned()
+        .map_or_else(|| ToolOutput::Text(String::new()), tool_output);
+    Some(Message {
+        role: Role::User,
+        content: vec![Block::ToolResult {
+            tool_use_id,
+            is_error: tool_result_is_error(row, &content),
+            content,
+        }],
+        timestamp,
+        model: None,
+        stop_reason: None,
+        usage: None,
+    })
+}
+
+fn tool_output(value: Value) -> ToolOutput {
+    match value {
+        Value::String(text) => serde_json::from_str::<Value>(&text)
+            .ok()
+            .filter(|v| v.is_object() || v.is_array())
+            .map_or(ToolOutput::Text(text), ToolOutput::Json),
+        other => ToolOutput::Json(other),
+    }
+}
+
+fn tool_result_is_error(row: &Value, output: &ToolOutput) -> bool {
+    if row.get("effect_disposition").and_then(Value::as_str) == Some("denied") {
+        return true;
+    }
+    match output {
+        ToolOutput::Json(value) => {
+            value.get("success").and_then(Value::as_bool) == Some(false)
+                || value
+                    .get("exit_code")
+                    .and_then(Value::as_i64)
+                    .is_some_and(|code| code != 0)
+                || value.get("error").is_some_and(|error| !error.is_null())
+        }
+        ToolOutput::Text(_) => false,
+    }
+}
+
+fn text_content(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::Null => None,
+        Value::String(text) => Some(text.clone()),
+        other => Some(value_text(other)),
+    }
+}
+
+fn value_text(value: &Value) -> String {
+    value
+        .as_str()
+        .map_or_else(|| value.to_string(), String::from)
+}
+
+fn parse_finish_reason(reason: &str) -> StopReason {
+    match reason {
+        "stop" | "end_turn" => StopReason::EndTurn,
+        "tool_calls" | "tool_use" => StopReason::ToolUse,
+        "length" | "max_tokens" => StopReason::MaxTokens,
+        "stop_sequence" => StopReason::StopSequence,
+        "aborted" | "cancelled" => StopReason::Aborted,
+        "error" => StopReason::Error,
+        other => StopReason::Other(other.to_string()),
+    }
+}
+
+fn finish_reason(reason: Option<&StopReason>, has_tools: bool) -> &'static str {
+    match reason {
+        Some(StopReason::MaxTokens) => "length",
+        Some(StopReason::StopSequence) => "stop_sequence",
+        Some(StopReason::Aborted) => "aborted",
+        Some(StopReason::Error) => "error",
+        Some(StopReason::EndTurn | StopReason::Other(_)) | None if !has_tools => "stop",
+        Some(StopReason::ToolUse | StopReason::EndTurn | StopReason::Other(_)) | None => {
+            "tool_calls"
+        }
+    }
+}
+
+fn stable_hash<T: serde::Serialize>(value: &T) -> String {
+    let bytes = serde_json::to_vec(value).unwrap_or_default();
+    Uuid::new_v5(&Uuid::NAMESPACE_URL, &bytes)
+        .simple()
+        .to_string()
+}
+
+fn export_from_messages(meta: &Meta, messages: &[Message]) -> Value {
+    let session_id = if meta.id.is_empty() {
+        format!(
+            "{}_{}",
+            meta.timestamp.format("%Y%m%d_%H%M%S"),
+            stable_hash(&(meta, messages))
+        )
+    } else {
+        meta.id.clone()
+    };
+    let rows = rows_from_messages(&session_id, messages);
+
+    json!({
+        "id": session_id,
+        "source": "txcript",
+        "model": meta.model,
+        "started_at": timestamp_seconds(meta.timestamp),
+        "cwd": meta.cwd,
+        "git_branch": meta.git_branch,
+        "title": meta.title,
+        "message_count": rows.len(),
+        "tool_call_count": rows.iter()
+            .filter(|row| row.get("role").and_then(Value::as_str) == Some("assistant"))
+            .filter_map(|row| row.get("tool_calls").and_then(Value::as_array))
+            .map(Vec::len)
+            .sum::<usize>(),
+        "messages": rows
+    })
+}
+
+fn rows_from_messages(session_id: &str, messages: &[Message]) -> Vec<Value> {
+    let mut rows = Vec::new();
+    let mut next_id = 1_u64;
+    for message in messages {
+        match message.role {
+            Role::User => {
+                for block in &message.content {
+                    if let Block::ToolResult {
+                        tool_use_id,
+                        content,
+                        is_error,
+                    } = block
+                    {
+                        rows.push(json!({
+                            "id": next_id,
+                            "session_id": session_id,
+                            "role": "tool",
+                            "content": output_value(content),
+                            "tool_call_id": tool_use_id,
+                            "effect_disposition": if *is_error { "denied" } else { "allowed" },
+                            "timestamp": timestamp_seconds(message.timestamp),
+                            "observed": 0,
+                            "active": 1,
+                            "compacted": 0
+                        }));
+                        next_id += 1;
+                    }
+                }
+                let native = native_content(&message.content);
+                if !native.is_null() {
+                    rows.push(base_row(
+                        next_id,
+                        session_id,
+                        "user",
+                        &native,
+                        message.timestamp,
+                    ));
+                    next_id += 1;
+                }
+            }
+            Role::Assistant => {
+                let mut reasoning = Vec::new();
+                let mut encrypted = None;
+                let mut calls = Vec::new();
+                for block in &message.content {
+                    match block {
+                        Block::Thinking {
+                            text: value,
+                            encrypted: value_encrypted,
+                            ..
+                        } => {
+                            reasoning.push(value.clone());
+                            encrypted = encrypted.or_else(|| value_encrypted.clone());
+                        }
+                        Block::ToolUse { id, tool } => calls.push(tool_call_value(id, tool)),
+                        Block::Text { .. } | Block::Image { .. } | Block::ToolResult { .. } => {}
+                    }
+                }
+                let has_tools = !calls.is_empty();
+                let native = native_content(&message.content);
+                let mut row =
+                    base_row(next_id, session_id, "assistant", &native, message.timestamp);
+                if let Some(object) = row.as_object_mut() {
+                    if !reasoning.is_empty() {
+                        object.insert("reasoning_content".into(), json!(reasoning.join("\n")));
+                    }
+                    if let Some(value) = encrypted {
+                        object.insert("codex_reasoning_items".into(), json!(value));
+                    }
+                    if has_tools {
+                        object.insert("tool_calls".into(), Value::Array(calls));
+                    }
+                    object.insert(
+                        "finish_reason".into(),
+                        json!(finish_reason(message.stop_reason.as_ref(), has_tools)),
+                    );
+                }
+                rows.push(row);
+                next_id += 1;
+            }
+        }
+    }
+    rows
+}
+
+fn native_content(blocks: &[Block]) -> Value {
+    let has_image = blocks
+        .iter()
+        .any(|block| matches!(block, Block::Image { .. }));
+    if !has_image {
+        let text = blocks
+            .iter()
+            .filter_map(|block| match block {
+                Block::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        return if text.is_empty() {
+            Value::Null
+        } else {
+            Value::String(text)
+        };
+    }
+    Value::Array(
+        blocks
+            .iter()
+            .filter_map(|block| match block {
+                Block::Text { text } => Some(json!({"type": "text", "text": text})),
+                Block::Image { source } => Some(json!({
+                    "type": "image_url",
+                    "image_url": {
+                        "url": format!("data:{};base64,{}", source.media_type, source.data)
+                    }
+                })),
+                _ => None,
+            })
+            .collect(),
+    )
+}
+
+fn base_row(
+    id: u64,
+    session_id: &str,
+    role: &str,
+    content: &Value,
+    timestamp: DateTime<Utc>,
+) -> Value {
+    json!({
+        "id": id,
+        "session_id": session_id,
+        "role": role,
+        "content": content,
+        "timestamp": timestamp_seconds(timestamp),
+        "observed": 0,
+        "active": 1,
+        "compacted": 0
+    })
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn timestamp_seconds(timestamp: DateTime<Utc>) -> f64 {
+    timestamp.timestamp() as f64 + f64::from(timestamp.timestamp_subsec_nanos()) / 1_000_000_000.0
+}
+
+fn tool_call_value(id: &str, tool: &Tool) -> Value {
+    let (name, input) = denormalize_tool(tool);
+    json!({
+        "id": id,
+        "call_id": id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": input.to_string()
+        }
+    })
+}
+
+fn denormalize_tool(tool: &Tool) -> (String, Value) {
+    match tool {
+        Tool::Read { .. } => {
+            let (_, mut input) = tool.to_canonical();
+            if let Some(object) = input.as_object_mut() {
+                rename_key(object, "file_path", "path");
+            }
+            ("read_file".to_string(), input)
+        }
+        Tool::Write { .. } => {
+            let (_, mut input) = tool.to_canonical();
+            if let Some(object) = input.as_object_mut() {
+                rename_key(object, "file_path", "path");
+            }
+            ("write_file".to_string(), input)
+        }
+        Tool::Edit { .. } => {
+            let (_, mut input) = tool.to_canonical();
+            if let Some(object) = input.as_object_mut() {
+                rename_key(object, "file_path", "path");
+                object.insert("mode".into(), json!("replace"));
+            }
+            ("patch".to_string(), input)
+        }
+        Tool::Bash { .. } => {
+            let (_, mut input) = tool.to_canonical();
+            if let Some(object) = input.as_object_mut() {
+                rename_key(object, "run_in_background", "background");
+                if let Some(milliseconds) = object.remove("timeout_ms") {
+                    let seconds = milliseconds
+                        .as_u64()
+                        .map(|ms| ms / 1000)
+                        .unwrap_or_default();
+                    object.insert("timeout".into(), json!(seconds));
+                }
+            }
+            ("terminal".to_string(), input)
+        }
+        // Commands keep their canonical slash-prefixed name; no Hermes tool
+        // name may collide with it, so the round trip is the identity.
+        Tool::MultiEdit { .. } | Tool::Raw { .. } | Tool::Command { .. } => tool.to_canonical(),
+    }
+}
+
+fn output_value(output: &ToolOutput) -> Value {
+    match output {
+        ToolOutput::Text(text) => Value::String(text.clone()),
+        ToolOutput::Json(value) => value.clone(),
+    }
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -13,6 +13,7 @@ pub mod codex;
 pub mod cursor;
 pub mod cursor_desktop;
 pub mod grok;
+pub mod hermes;
 pub mod opencode;
 pub mod pi;
 pub mod simple;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 //! Typed conversion for coding-agent session transcripts.
 //!
-//! Claude Code, Codex, `OpenCode`, pi, Campfire, Cursor, and Grok record
-//! similar conversation data in different on-disk formats. This crate maps
-//! each format through [`Transcript<Common>`] and converts with
-//! [`convert::<A, B>`](convert): `A` -> [`Common`] -> `B`.
+//! Claude Code, Codex, `OpenCode`, pi, Campfire, Cursor, Grok, Hermes, Amp,
+//! and Antigravity record similar conversation data in different on-disk
+//! formats. This crate maps each format through [`Transcript<Common>`] and
+//! converts with [`convert::<A, B>`](convert): `A` -> [`Common`] -> `B`.
 //!
 //! # Fidelity
 //!

--- a/src/local.rs
+++ b/src/local.rs
@@ -22,6 +22,9 @@ use chrono::{DateTime, Utc};
 use crate::common::Meta;
 use crate::harness::{amp, antigravity, campfire, claude_code, codex, cursor, grok, pi};
 
+#[cfg(feature = "hermes")]
+use crate::harness::hermes;
+
 #[cfg(feature = "opencode")]
 use crate::harness::cursor_desktop;
 use crate::{Codec, Common, Error, HarnessId, Result, Store, Transcript};
@@ -43,7 +46,7 @@ pub struct Session {
 
 enum Locator {
     Path(PathBuf),
-    #[cfg(feature = "opencode")]
+    #[cfg(any(feature = "opencode", feature = "hermes"))]
     Id(String),
 }
 
@@ -110,6 +113,22 @@ pub fn discover_with(mut on_store: impl FnMut(HarnessId, usize)) -> Vec<Session>
         &mut out,
     );
 
+    #[cfg(feature = "hermes")]
+    {
+        on_store(HarnessId::Hermes, out.len());
+        if let Some(store) = hermes::HermesStore::default_root() {
+            for d in store.discover().unwrap_or_default() {
+                out.push(Session {
+                    harness: HarnessId::Hermes,
+                    meta: d.meta,
+                    // The database doesn't surface a per-session mtime.
+                    updated_at: None,
+                    locator: Locator::Id(d.reference),
+                });
+            }
+        }
+    }
+
     #[cfg(feature = "opencode")]
     {
         on_store(HarnessId::CursorDesktop, out.len());
@@ -154,7 +173,7 @@ impl Session {
         match &self.locator {
             Locator::Path(p) => p.display().to_string(),
             #[cfg(feature = "opencode")]
-            Locator::Id(id) => format!("opencode db session {id}"),
+            Locator::Id(id) => format!("{} db session {id}", self.harness),
         }
     }
 
@@ -185,6 +204,10 @@ impl Session {
             (HarnessId::Amp, Locator::Path(p)) => go(amp::AmpStore::default_root(), p),
             (HarnessId::Antigravity, Locator::Path(p)) => {
                 go(antigravity::AntigravityStore::default_root(), p)
+            }
+            #[cfg(feature = "hermes")]
+            (HarnessId::Hermes, Locator::Id(id)) => {
+                hermes::Hermes::to_common(&required(hermes::HermesStore::default_root())?.load(id)?)
             }
             #[cfg(feature = "opencode")]
             (HarnessId::CursorDesktop, Locator::Id(id)) => {
@@ -226,6 +249,11 @@ impl Session {
             (HarnessId::Antigravity, Locator::Path(p)) => {
                 go(antigravity::AntigravityStore::default_root(), p)
             }
+            // Errors: the Hermes store is read-only.
+            #[cfg(feature = "hermes")]
+            (HarnessId::Hermes, Locator::Id(id)) => {
+                required(hermes::HermesStore::default_root())?.delete(id)
+            }
             #[cfg(feature = "opencode")]
             (HarnessId::CursorDesktop, Locator::Id(id)) => {
                 required(cursor_desktop::CursorDesktopStore::default_root())?.delete(id)
@@ -260,6 +288,9 @@ pub struct Written {
 ///
 /// # Errors
 /// When conversion to the target fails or its store rejects the write.
+// One dispatch arm per harness; length grows with the harness count, not
+// with complexity.
+#[allow(clippy::too_many_lines)]
 pub fn write(
     target: HarnessId,
     common: &Transcript<Common>,
@@ -332,6 +363,16 @@ pub fn write(
             common,
             |s| s.sessions_dir,
         ),
+        // Hermes's state.db is read-only in txcript and Hermes has no
+        // session-import command. Sessions convert *from* Hermes, never
+        // into it.
+        HarnessId::Hermes => Err(Error::Unconvertible {
+            harness: "hermes",
+            detail: "Hermes state.db is read-only and Hermes has no session \
+                     import command; sessions can be converted from Hermes, \
+                     but not continued into it"
+                .to_string(),
+        }),
         // Amp is server-authoritative: threads live on ampcode.com and the
         // CLI has no import, so a locally written thread can never be
         // resumed. Sessions convert *from* amp, never into it.
@@ -443,6 +484,7 @@ pub fn resume_command(harness: HarnessId, id: &str) -> (String, Vec<String>) {
             // the session is in the Agents sidebar.
             HarnessId::CursorDesktop => ("cursor".into(), Vec::new()),
             HarnessId::Grok => ("grok".into(), vec!["--resume".into(), id]),
+            HarnessId::Hermes => ("hermes".into(), vec!["--resume".into(), id]),
             HarnessId::Amp => ("amp".into(), vec!["threads".into(), "continue".into(), id]),
             HarnessId::Antigravity => ("agy".into(), vec![format!("--conversation={id}")]),
             // Unreachable in practice: Simple sessions are neither discovered

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -240,13 +240,14 @@ pub enum HarnessId {
     Cursor,
     CursorDesktop,
     Grok,
+    Hermes,
     Amp,
     Antigravity,
     Simple,
 }
 
 impl HarnessId {
-    pub const ALL: [HarnessId; 11] = [
+    pub const ALL: [HarnessId; 12] = [
         HarnessId::ClaudeCode,
         HarnessId::Codex,
         HarnessId::OpenCode,
@@ -255,6 +256,7 @@ impl HarnessId {
         HarnessId::Cursor,
         HarnessId::CursorDesktop,
         HarnessId::Grok,
+        HarnessId::Hermes,
         HarnessId::Amp,
         HarnessId::Antigravity,
         HarnessId::Simple,
@@ -272,6 +274,7 @@ impl HarnessId {
             HarnessId::Cursor => "cursor",
             HarnessId::CursorDesktop => "cursor_desktop",
             HarnessId::Grok => "grok",
+            HarnessId::Hermes => "hermes",
             HarnessId::Amp => "amp",
             HarnessId::Antigravity => "antigravity",
             HarnessId::Simple => "simple",
@@ -303,6 +306,7 @@ impl FromStr for HarnessId {
             "grok" | "grok_cli" | "grok-cli" | "grokcli" | "grok_build" | "grok-build" => {
                 Ok(HarnessId::Grok)
             }
+            "hermes" | "hermes_agent" | "hermes-agent" | "hermesagent" => Ok(HarnessId::Hermes),
             "amp" | "ampcode" | "amp_code" | "amp-code" => Ok(HarnessId::Amp),
             "antigravity" | "agy" | "antigravity_cli" | "antigravity-cli" | "anti-gravity" => {
                 Ok(HarnessId::Antigravity)

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -14,8 +14,8 @@ use wasm_bindgen::prelude::*;
 
 use crate::common;
 use crate::harness::{
-    amp, antigravity, campfire, claude_code, codex, cursor, cursor_desktop, grok, opencode, pi,
-    simple,
+    amp, antigravity, campfire, claude_code, codex, cursor, cursor_desktop, grok, hermes, opencode,
+    pi, simple,
 };
 use crate::transcript::{Codec, Common, HarnessId, TextCodec, Transcript};
 
@@ -24,11 +24,12 @@ use crate::transcript::{Codec, Common, HarnessId, TextCodec, Transcript};
 /// `input` is the source session text (JSONL for `claude_code`/codex/pi/campfire,
 /// the Cursor JSON DB export for cursor, the JSON dump of the session's
 /// database rows for `cursor_desktop`, the `opencode export` JSON for
-/// opencode, the JSON bundle of the session directory for grok, the thread
-/// JSON document for amp, the JSON dump of the conversation database for
-/// antigravity, the interchange JSON document for simple); `from`/`to` are
-/// harness names (`"claude_code"`, `"codex"`, `"opencode"`, `"pi"`,
-/// `"campfire"`, `"cursor"`, `"cursor_desktop"`, `"grok"`, `"amp"`,
+/// opencode, the JSON bundle of the session directory for grok, the
+/// `hermes sessions export` JSON object for hermes, the thread JSON document
+/// for amp, the JSON dump of the conversation database for antigravity, the
+/// interchange JSON document for simple); `from`/`to` are harness names
+/// (`"claude_code"`, `"codex"`, `"opencode"`, `"pi"`, `"campfire"`,
+/// `"cursor"`, `"cursor_desktop"`, `"grok"`, `"hermes"`, `"amp"`,
 /// `"antigravity"`, `"simple"`). Returns the target harness's native text.
 #[wasm_bindgen]
 pub fn convert(input: &str, from: &str, to: &str) -> Result<String, JsError> {
@@ -200,6 +201,7 @@ fn parse_to_common(harness: HarnessId, text: &str) -> crate::Result<Transcript<C
         HarnessId::Cursor => go::<cursor::Cursor>(text),
         HarnessId::CursorDesktop => go::<cursor_desktop::CursorDesktop>(text),
         HarnessId::Grok => go::<grok::Grok>(text),
+        HarnessId::Hermes => go::<hermes::Hermes>(text),
         HarnessId::Amp => go::<amp::Amp>(text),
         HarnessId::Antigravity => go::<antigravity::Antigravity>(text),
         HarnessId::Simple => go::<simple::Simple>(text),
@@ -219,6 +221,7 @@ fn render_from_common(harness: HarnessId, common: &Transcript<Common>) -> crate:
         HarnessId::Cursor => go::<cursor::Cursor>(common),
         HarnessId::CursorDesktop => go::<cursor_desktop::CursorDesktop>(common),
         HarnessId::Grok => go::<grok::Grok>(common),
+        HarnessId::Hermes => go::<hermes::Hermes>(common),
         HarnessId::Amp => go::<amp::Amp>(common),
         HarnessId::Antigravity => go::<antigravity::Antigravity>(common),
         HarnessId::Simple => go::<simple::Simple>(common),

--- a/tests/integration/cross_harness.rs
+++ b/tests/integration/cross_harness.rs
@@ -6,8 +6,8 @@
 use chrono::{DateTime, Utc};
 use txcript::common;
 use txcript::harness::{
-    amp, antigravity, campfire, claude_code, codex, cursor, cursor_desktop, grok, opencode, pi,
-    simple,
+    amp, antigravity, campfire, claude_code, codex, cursor, cursor_desktop, grok, hermes, opencode,
+    pi, simple,
 };
 use txcript::{Codec, Common, Transcript, convert};
 
@@ -185,7 +185,14 @@ fn conversation_survives_every_hop() {
         "grok"
     );
 
-    let amp = convert::<grok::Grok, amp::Amp>(&grok).unwrap();
+    let hermes = convert::<grok::Grok, hermes::Hermes>(&grok).unwrap();
+    assert_eq!(
+        signature(&hermes::Hermes::to_common(&hermes).unwrap()),
+        expected,
+        "hermes"
+    );
+
+    let amp = convert::<hermes::Hermes, amp::Amp>(&hermes).unwrap();
     assert_eq!(
         signature(&amp::Amp::to_common(&amp).unwrap()),
         expected,

--- a/tests/integration/hermes.rs
+++ b/tests/integration/hermes.rs
@@ -1,0 +1,493 @@
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
+//! Integration tests for Hermes Agent's exported session and `SQLite` store.
+
+use chrono::{DateTime, Utc};
+use serde_json::json;
+#[cfg(feature = "hermes")]
+use txcript::Store;
+use txcript::harness::hermes;
+use txcript::{Codec, Common, TextCodec, Transcript};
+
+fn ts(s: &str) -> DateTime<Utc> {
+    s.parse().unwrap()
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn exported_session_preserves_conversation_tools_and_reasoning() {
+    let export = json!({
+        "id": "20260717_120337_deadbeef",
+        "source": "cli",
+        "model": "gpt-5.6-sol",
+        "started_at": 1_768_000_000.0,
+        "cwd": "/repo",
+        "git_branch": "main",
+        "title": "Hermes demo",
+        "messages": [
+            {
+                "id": 1,
+                "session_id": "20260717_120337_deadbeef",
+                "role": "user",
+                "content": "read the file",
+                "timestamp": 1_768_000_001.0,
+                "active": 1,
+                "compacted": 0
+            },
+            {
+                "id": 2,
+                "session_id": "20260717_120337_deadbeef",
+                "role": "assistant",
+                "content": "I'll inspect it.",
+                "tool_calls": [{
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": "{\"path\":\"/repo/README.md\",\"offset\":1}"
+                    }
+                }],
+                "reasoning_content": "Need to inspect the requested file.",
+                "finish_reason": "tool_calls",
+                "timestamp": 1_768_000_002.0,
+                "active": 1,
+                "compacted": 0
+            },
+            {
+                "id": 3,
+                "session_id": "20260717_120337_deadbeef",
+                "role": "tool",
+                "content": "{\"content\":\"1|# Demo\",\"total_lines\":1}",
+                "tool_call_id": "call-1",
+                "tool_name": "read_file",
+                "timestamp": 1_768_000_003.0,
+                "active": 1,
+                "compacted": 0
+            },
+            {
+                "id": 4,
+                "session_id": "20260717_120337_deadbeef",
+                "role": "assistant",
+                "content": "README loaded.",
+                "finish_reason": "stop",
+                "timestamp": 1_768_000_004.0,
+                "active": 1,
+                "compacted": 0
+            },
+            {
+                "id": 5,
+                "session_id": "20260717_120337_deadbeef",
+                "role": "session_meta",
+                "content": null,
+                "timestamp": 1_768_000_005.0,
+                "active": 1,
+                "compacted": 0,
+                "future_field": {"kept": true}
+            }
+        ],
+        "future_session_field": {"kept": true}
+    });
+
+    let text = serde_json::to_string(&export).unwrap();
+    let native = hermes::Hermes::from_text(&text).unwrap();
+    assert_eq!(native.body, export);
+    assert_eq!(native.meta.id, "20260717_120337_deadbeef");
+    assert_eq!(native.meta.timestamp, ts("2026-01-09T23:06:40Z"));
+    assert_eq!(native.meta.cwd.as_deref(), Some("/repo"));
+    assert_eq!(native.meta.git_branch.as_deref(), Some("main"));
+    assert_eq!(native.meta.title.as_deref(), Some("Hermes demo"));
+    assert_eq!(native.meta.model.as_deref(), Some("gpt-5.6-sol"));
+
+    let common = hermes::Hermes::to_common(&native).unwrap();
+    assert_eq!(common.body.len(), 4);
+    assert!(matches!(
+        &common.body[1].content[0],
+        txcript::common::Block::Thinking { text, .. }
+            if text == "Need to inspect the requested file."
+    ));
+    assert!(matches!(
+        &common.body[1].content[2],
+        txcript::common::Block::ToolUse {
+            id,
+            tool: txcript::common::Tool::Read { file_path, offset: Some(1), .. },
+        } if id == "call-1" && file_path == "/repo/README.md"
+    ));
+    assert!(matches!(
+        &common.body[2].content[0],
+        txcript::common::Block::ToolResult {
+            tool_use_id,
+            content: txcript::common::ToolOutput::Json(value),
+            is_error: false,
+        } if tool_use_id == "call-1" && value["content"] == "1|# Demo"
+    ));
+    assert_eq!(
+        common.body[3].stop_reason,
+        Some(txcript::common::StopReason::EndTurn)
+    );
+
+    let rendered = hermes::Hermes::to_text(&native).unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&rendered).unwrap(),
+        export
+    );
+}
+
+fn sample_common() -> Transcript<Common> {
+    let meta = txcript::common::Meta {
+        id: "hermes-fixpoint".into(),
+        timestamp: ts("2026-01-02T03:04:05Z"),
+        cwd: Some("/repo".into()),
+        git_branch: Some("feat/demo".into()),
+        title: Some("Hermes fixpoint".into()),
+        cli_version: None,
+        model: Some("gpt-5.6-sol".into()),
+    };
+    Transcript::new(
+        meta,
+        vec![
+            txcript::common::Message {
+                role: txcript::common::Role::User,
+                content: vec![txcript::common::Block::Text {
+                    text: "read it".into(),
+                }],
+                timestamp: ts("2026-01-02T03:04:06Z"),
+                model: None,
+                stop_reason: None,
+                usage: None,
+            },
+            txcript::common::Message {
+                role: txcript::common::Role::Assistant,
+                content: vec![
+                    txcript::common::Block::Thinking {
+                        text: "I should inspect it.".into(),
+                        signature: None,
+                        encrypted: Some("opaque-reasoning".into()),
+                    },
+                    txcript::common::Block::Text {
+                        text: "Inspecting.".into(),
+                    },
+                    txcript::common::Block::ToolUse {
+                        id: "call-1".into(),
+                        tool: txcript::common::Tool::Read {
+                            file_path: "/repo/README.md".into(),
+                            offset: Some(1),
+                            limit: Some(20),
+                        },
+                    },
+                ],
+                timestamp: ts("2026-01-02T03:04:07Z"),
+                model: Some("gpt-5.6-sol".into()),
+                stop_reason: Some(txcript::common::StopReason::ToolUse),
+                usage: None,
+            },
+            txcript::common::Message {
+                role: txcript::common::Role::User,
+                content: vec![txcript::common::Block::ToolResult {
+                    tool_use_id: "call-1".into(),
+                    content: txcript::common::ToolOutput::Json(json!({"content": "demo"})),
+                    is_error: false,
+                }],
+                timestamp: ts("2026-01-02T03:04:08Z"),
+                model: None,
+                stop_reason: None,
+                usage: None,
+            },
+            txcript::common::Message {
+                role: txcript::common::Role::Assistant,
+                content: vec![txcript::common::Block::Text {
+                    text: "Done.".into(),
+                }],
+                timestamp: ts("2026-01-02T03:04:09Z"),
+                model: Some("gpt-5.6-sol".into()),
+                stop_reason: Some(txcript::common::StopReason::EndTurn),
+                usage: None,
+            },
+        ],
+    )
+}
+
+#[test]
+fn codec_fixpoint_through_common_loses_nothing() {
+    let common = sample_common();
+    let native = hermes::Hermes::from_common(&common).unwrap();
+    let round = hermes::Hermes::to_common(&native).unwrap();
+    assert_eq!(round, common);
+}
+
+#[test]
+fn from_common_is_deterministic() {
+    let common = sample_common();
+    let first = hermes::Hermes::from_common(&common).unwrap();
+    let second = hermes::Hermes::from_common(&common).unwrap();
+    assert_eq!(
+        hermes::Hermes::to_text(&first).unwrap(),
+        hermes::Hermes::to_text(&second).unwrap()
+    );
+}
+
+#[test]
+fn from_common_with_empty_id_is_deterministic() {
+    let mut common = sample_common();
+    common.meta.id.clear();
+    let first = hermes::Hermes::from_common(&common).unwrap();
+    let second = hermes::Hermes::from_common(&common).unwrap();
+    assert_eq!(first.body, second.body);
+    assert_eq!(first.meta.id, second.meta.id);
+    assert!(!first.meta.id.is_empty());
+}
+
+#[test]
+fn missing_or_invalid_started_at_uses_stable_epoch() {
+    for text in [
+        r#"{"id":"missing","messages":[]}"#,
+        r#"{"id":"invalid","started_at":"nope","messages":[]}"#,
+    ] {
+        let first = hermes::Hermes::from_text(text).unwrap();
+        let second = hermes::Hermes::from_text(text).unwrap();
+        assert_eq!(first.meta.timestamp, second.meta.timestamp);
+        assert_eq!(first.meta.timestamp, DateTime::<Utc>::UNIX_EPOCH);
+    }
+}
+
+#[test]
+fn encrypted_reasoning_survives_without_plaintext() {
+    let text = json!({
+        "id": "encrypted-only",
+        "started_at": 1_768_000_000.0,
+        "messages": [{
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": "[{\"type\":\"reasoning\",\"encrypted_content\":\"opaque\"}]",
+            "timestamp": 1_768_000_001.0,
+            "active": 1
+        }]
+    })
+    .to_string();
+    let native = hermes::Hermes::from_text(&text).unwrap();
+    let common = hermes::Hermes::to_common(&native).unwrap();
+    assert!(matches!(
+        &common.body[0].content[0],
+        txcript::common::Block::Thinking {
+            text,
+            encrypted: Some(value),
+            ..
+        } if text.is_empty() && value.contains("encrypted_content")
+    ));
+}
+
+#[test]
+fn malformed_tool_arguments_remain_raw() {
+    let text = json!({
+        "id": "malformed-args",
+        "started_at": 1_768_000_000.0,
+        "messages": [{
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call-raw",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "not-json"}
+            }],
+            "timestamp": 1_768_000_001.0,
+            "active": 1
+        }]
+    })
+    .to_string();
+    let native = hermes::Hermes::from_text(&text).unwrap();
+    let common = hermes::Hermes::to_common(&native).unwrap();
+    assert!(matches!(
+        &common.body[0].content[0],
+        txcript::common::Block::ToolUse {
+            tool: txcript::common::Tool::Raw { tool_name, input },
+            ..
+        } if tool_name == "read_file" && input == "not-json"
+    ));
+}
+
+#[test]
+fn multimodal_content_and_parallel_tool_count_survive() {
+    let text = json!({
+        "id": "multimodal",
+        "started_at": 1_768_000_000.0,
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "inspect this"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,aGVsbG8="}}
+            ],
+            "timestamp": 1_768_000_001.0,
+            "active": 1
+        }]
+    })
+    .to_string();
+    let native = hermes::Hermes::from_text(&text).unwrap();
+    let common = hermes::Hermes::to_common(&native).unwrap();
+    assert!(
+        matches!(&common.body[0].content[0], txcript::common::Block::Text { text } if text == "inspect this")
+    );
+    assert!(matches!(
+        &common.body[0].content[1],
+        txcript::common::Block::Image { source }
+            if source.media_type == "image/png" && source.data == "aGVsbG8="
+    ));
+    let round = hermes::Hermes::to_common(&hermes::Hermes::from_common(&common).unwrap()).unwrap();
+    assert_eq!(round, common);
+
+    let mut with_calls = common;
+    with_calls.body.push(txcript::common::Message {
+        role: txcript::common::Role::Assistant,
+        content: vec![
+            txcript::common::Block::ToolUse {
+                id: "call-a".into(),
+                tool: txcript::common::Tool::Raw {
+                    tool_name: "one".into(),
+                    input: json!({}),
+                },
+            },
+            txcript::common::Block::ToolUse {
+                id: "call-b".into(),
+                tool: txcript::common::Tool::Raw {
+                    tool_name: "two".into(),
+                    input: json!({}),
+                },
+            },
+        ],
+        timestamp: ts("2026-01-09T23:06:42Z"),
+        model: None,
+        stop_reason: Some(txcript::common::StopReason::ToolUse),
+        usage: None,
+    });
+    let native = hermes::Hermes::from_common(&with_calls).unwrap();
+    assert_eq!(native.body["tool_call_count"], 2);
+}
+
+#[test]
+#[cfg(feature = "hermes")]
+#[allow(clippy::too_many_lines)]
+fn sqlite_store_discovers_and_loads_export_shape_read_only() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("state.db");
+    let conn = rusqlite::Connection::open(&db).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE sessions (
+             id TEXT PRIMARY KEY,
+             source TEXT NOT NULL,
+             model TEXT,
+             started_at REAL NOT NULL,
+             cwd TEXT,
+             git_branch TEXT,
+             title TEXT,
+             archived INTEGER NOT NULL DEFAULT 0
+         );
+         CREATE TABLE messages (
+             id INTEGER PRIMARY KEY,
+             session_id TEXT NOT NULL,
+             role TEXT NOT NULL,
+             content TEXT,
+             tool_call_id TEXT,
+             tool_calls TEXT,
+             tool_name TEXT,
+             timestamp REAL NOT NULL,
+             active INTEGER NOT NULL DEFAULT 1,
+             compacted INTEGER NOT NULL DEFAULT 0
+         );
+         INSERT INTO sessions VALUES (
+             'hermes-db-1', 'cli', 'gpt-5.6-sol', 1768000000.0,
+             '/repo', 'main', 'Database demo', 0
+         );
+         INSERT INTO messages VALUES (
+             1, 'hermes-db-1', 'user', 'hello', NULL, NULL, NULL,
+             1768000003.0, 1, 0
+         );
+         INSERT INTO messages VALUES (
+             2, 'hermes-db-1', 'assistant', '', NULL,
+             '[{\"id\":\"call-1\",\"type\":\"function\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\\\"/repo/README.md\\\"}\"}}]',
+             NULL, 1768000001.0, 1, 0
+         );
+         INSERT INTO messages VALUES (
+             3, 'hermes-db-1', 'tool', '{\"content\":\"demo\"}', 'call-1',
+             NULL, 'read_file', 1768000002.0, 1, 0
+         );
+         INSERT INTO messages VALUES (
+             4, 'hermes-db-1', 'assistant', '', NULL, 'not-json', NULL,
+             1768000004.0, 1, 0
+         );
+         INSERT INTO messages VALUES (
+             5, 'hermes-db-1', 'user', 'rewound secret', NULL, NULL, NULL,
+             1768000005.0, 0, 0
+         );",
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE messages SET content = ?1 WHERE id = 1",
+        ["\0json:[{\"type\":\"text\",\"text\":\"hello\"}]"],
+    )
+    .unwrap();
+    drop(conn);
+
+    let before = std::fs::read(&db).unwrap();
+    let store = hermes::HermesStore::new(&db);
+    let found = store.discover().unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].meta.id, "hermes-db-1");
+    assert_eq!(found[0].meta.cwd.as_deref(), Some("/repo"));
+    assert_eq!(found[0].meta.title.as_deref(), Some("Database demo"));
+
+    let loaded = store.load(&found[0].reference).unwrap();
+    assert_eq!(
+        loaded.body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|row| row["id"].as_i64().unwrap())
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3, 4]
+    );
+    assert!(loaded.body["messages"][0]["content"].is_array());
+    assert!(loaded.body["messages"][1]["tool_calls"].is_array());
+    assert_eq!(
+        loaded.body["messages"][2]["content"],
+        "{\"content\":\"demo\"}"
+    );
+    assert_eq!(loaded.body["messages"][3]["tool_calls"], json!([]));
+    let common = hermes::Hermes::to_common(&loaded).unwrap();
+    assert_eq!(common.body.len(), 3);
+    assert!(matches!(
+        &common.body[1].content[0],
+        txcript::common::Block::ToolUse { id, .. } if id == "call-1"
+    ));
+
+    let error = store.save(&loaded).unwrap_err().to_string();
+    assert!(error.contains("read-only"));
+    assert!(store.delete(&found[0].reference).is_err());
+    let first_fingerprint =
+        store.fingerprints(&[found[0].reference.clone()]).unwrap()[&found[0].reference].clone();
+    assert_eq!(std::fs::read(&db).unwrap(), before);
+
+    let conn = rusqlite::Connection::open(&db).unwrap();
+    conn.execute("UPDATE messages SET content = 'edited' WHERE id = 2", [])
+        .unwrap();
+    drop(conn);
+    let second_fingerprint =
+        store.fingerprints(&[found[0].reference.clone()]).unwrap()[&found[0].reference].clone();
+    assert_ne!(first_fingerprint, second_fingerprint);
+
+    let conn = rusqlite::Connection::open(&db).unwrap();
+    conn.execute("UPDATE messages SET active = 0 WHERE id = 2", [])
+        .unwrap();
+    drop(conn);
+    let third_fingerprint =
+        store.fingerprints(&[found[0].reference.clone()]).unwrap()[&found[0].reference].clone();
+    assert_ne!(second_fingerprint, third_fingerprint);
+
+    let conn = rusqlite::Connection::open(&db).unwrap();
+    conn.execute(
+        "UPDATE sessions SET title = 'Renamed' WHERE id = 'hermes-db-1'",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+    let fourth_fingerprint =
+        store.fingerprints(&[found[0].reference.clone()]).unwrap()[&found[0].reference].clone();
+    assert_ne!(third_fingerprint, fourth_fingerprint);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -14,6 +14,7 @@ mod cross_harness;
 mod cursor;
 mod cursor_desktop;
 mod grok;
+mod hermes;
 mod opencode;
 mod path_safety;
 mod pi;

--- a/tests/integration/properties.rs
+++ b/tests/integration/properties.rs
@@ -18,8 +18,8 @@ use proptest::test_runner::TestCaseError;
 use serde_json::json;
 use txcript::common::{Block, Message, Meta, Role, Tool, ToolOutput};
 use txcript::harness::{
-    amp, antigravity, campfire, claude_code, codex, cursor, cursor_desktop, grok, opencode, pi,
-    simple,
+    amp, antigravity, campfire, claude_code, codex, cursor, cursor_desktop, grok, hermes, opencode,
+    pi, simple,
 };
 use txcript::{Codec, Common, Transcript};
 
@@ -262,6 +262,7 @@ proptest! {
         assert_fixpoint::<cursor::Cursor>("cursor", &common)?;
         assert_fixpoint::<cursor_desktop::CursorDesktop>("cursor_desktop", &common)?;
         assert_fixpoint::<grok::Grok>("grok", &common)?;
+        assert_fixpoint::<hermes::Hermes>("hermes", &common)?;
         assert_fixpoint::<amp::Amp>("amp", &common)?;
         assert_fixpoint::<antigravity::Antigravity>("antigravity", &common)?;
         assert_fixpoint::<simple::Simple>("simple", &common)?;


### PR DESCRIPTION
**Stack: 2/3** — stacked on #3 (the Simple format); shows only this layer's diff. Replaces #4, which GitHub auto-closed during a base rebase and cannot reopen.

Requirement: *"I should be able to continue this simple session into any of my harnesses"* — where the session is a document you hand over directly, not something txcript manages.

```sh
txcript continue ./run.json --with claude_code
my-agent --dump | txcript continue - --with claude_code
```

### Behavior

- The `continue` argument may be an existing file path or `-` (stdin); everything else falls through to the normal session lookup unchanged. A whole argument naming a real file wins over `#range` splitting, so filenames containing `#` still open; `#range` slicing otherwise works exactly as for ids.
- `--with` is required for documents (clear error otherwise); `--with simple` is refused (`simple` is an interchange input). `--from` with a document errors — it scopes session search.
- A document without an `id` borrows the file stem (the stores' filename convention) or gets a UUID; without a `cwd`, the copy is homed to the current directory, since target stores shard by cwd.
- Stdin-sourced continues reattach the controlling terminal (`/dev/tty` / `CONIN$`) as the launched harness's stdin — otherwise an interactive resume reads the exhausted pipe as EOF.
- A path-looking argument that names no file gets a file-flavored error instead of a bare "no session matches".

### Verification

Unit tests for document detection precedence and id fallback; full workspace tests + clippy pedantic clean. Live end-to-end: both the file form and the stdin form written into the real Claude Code store and resumed headlessly with the `claude` CLI, answering questions from the converted history; verification sessions cleaned up afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
