### PR TITLE
Add Cowork, Claude desktop's local agent mode, as a harness

### DIFF
--- a/.claude/skills/harness/references/patterns.md
+++ b/.claude/skills/harness/references/patterns.md
@@ -187,6 +187,43 @@ blindly.
   (RFC 3986 unreserved kept); a session dir is sniffed by the presence of
   either log; discovery meta comes cheap from `summary.json`.
 
+## cowork — app record + embedded Claude Code JSONL, consumer read from the app bundle
+
+- Body = `CoworkSession { header: Header (typed required/meta fields +
+  flatten extra), transcript: Vec<claude_code::Record>, audit: Vec<Value> }`.
+  The conversation IS Claude Code's JSONL under a per-task
+  `CLAUDE_CONFIG_DIR`, so the codec delegates to `claude_code`'s
+  `pub(crate)` `records_to_messages`/`messages_to_records` (extracted for
+  this; the campfire move applied to a non-sibling) with `meta.id` swapped
+  for the `cliSessionId`. Nothing Cowork-specific is re-parsed.
+- **The consumer was read, not probed**: the desktop app has no CLI, so the
+  regeneration contract came from its bundled JS (`npx @electron/asar
+  extract`, then grep the `.vite/build/*.chunk-*.js` for the session
+  manager). Its zod schema for `local_*.json` is `.passthrough()` with five
+  required keys (`sessionId`, `processName`, `cwd`, `createdAt`,
+  `lastActivityAt`); a record failing it is silently not listed. The
+  transcript is located by `cliSessionId` under *any* project slug, so the
+  slug need not match Claude Code's (hash-truncated) encoding of long cwds.
+- Shell gotcha that burned an hour: `grep` was aliased to ugrep, which
+  rejects long-context patterns on minified lines, and BSD grep caps `\{n\}`
+  at 255 — use a Python `re` script for bundle archaeology.
+- `audit.jsonl` is an HMAC chain keyed via Electron `safeStorage`: carried
+  verbatim on native round trips, never written (the app accepts unsigned
+  and absent logs). Synthesized fields: `processName` (`txcript-<8 hex>`),
+  `hostLoopMode: true` (host CLI, not the VM), `initialMessage`,
+  `lastActivityAt` = last message. `cliSessionId` = UUIDv5 of the session id.
+- Ids are `local_<uuid>`; foreign ids get the prefix (the one documented
+  `Meta` change through Common). Store root is the Electron userData dir;
+  account trees are `<org-uuid>/<account-uuid>/` (both levels UUID-shaped —
+  that's the sniff against sibling app state); `save` picks the tree with the
+  youngest record. The app loads records once at startup: a written session
+  shows up after quit + relaunch, and there is no per-session deep link
+  (`claude://resume?session=` targets the app's *Claude Code* surface).
+- Resume verification split: Cowork → Claude Code headless (`claude -p
+  --resume` from an unrelated cwd) and TUI; Claude Code → Cowork only via the
+  app, because the per-task config dir has no credentials (`claude -p` under
+  it says "Not logged in") — the user drives that check.
+
 ## Cross-cutting invariants (all)
 
 - Fallback-to-raw at every level: record → `Other(Value)`, tool →

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ txcript maps each harness's native transcript format through a typed common mode
 
 ## Highlights
 
-- **12 harnesses, one model**: every format converts through `Transcript<Common>`, so adding a harness connects it to all the others.
+- **13 harnesses, one model**: every format converts through `Transcript<Common>`, so adding a harness connects it to all the others.
 - **A format for everyone else**: agents txcript has never heard of emit the documented [Simple](docs/formats/simple.md) interchange JSON — a file or a stream, handed to txcript directly — and their transcripts continue in any supported harness.
 - **Byte-lossless round-trips**: loading and saving a session in its own format reproduces it exactly.
 - **Continue anywhere**: `txcript continue <id> --with <harness>` rewrites a session into another harness's native format and launches it. The original is never modified.
@@ -60,6 +60,7 @@ txcript maps each harness's native transcript format through a typed common mode
 ```mermaid
 flowchart LR
     claude["Claude Code"] <--> common(("Transcript&lt;Common&gt;"))
+    cowork["Cowork"] <--> common
     codex["Codex"] <--> common
     opencode["OpenCode"] <--> common
     pi["pi"] <--> common
@@ -78,6 +79,7 @@ Discovery, listing, search, `view`, and native round-trips work for every harnes
 | Harness | id | Sessions on disk | Native format | Convert | Continue into | Doc |
 |---|---|---|---|:---:|:---:|---|
 | [Claude Code](https://claude.com/claude-code) | `claude_code` | `~/.claude/projects/` | JSONL | ⇄ | ✓ | [spec](docs/formats/claude-code.md) |
+| [Cowork](https://claude.com/product/cowork) | `cowork` | `<Claude app data>/local-agent-mode-sessions/` | session record + Claude Code JSONL | ⇄ | ✓ | [spec](docs/formats/cowork.md) |
 | [Codex](https://github.com/openai/codex) | `codex` | `~/.codex/sessions/` | rollout JSONL | ⇄ | ✓ | [spec](docs/formats/codex.md) |
 | [OpenCode](https://opencode.ai) | `opencode` | `~/.local/share/opencode/opencode.db` | SQLite | ⇄ | ✓ | [spec](docs/formats/opencode.md) |
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [spec](docs/formats/pi.md) |
@@ -275,7 +277,7 @@ writeFileSync("session.jsonl", convert(input, "codex", "claude_code"));
 const common = JSON.parse(toCommon(input, "codex"));   // { meta, messages }
 const pi = fromCommon(JSON.stringify(common), "pi");
 
-harnesses(); // ["claude_code","codex","opencode","pi","campfire","cursor","cursor_desktop","grok","hermes","amp","antigravity","simple"]
+harnesses(); // ["claude_code","codex","opencode","pi","campfire","cursor","cursor_desktop","grok","hermes","amp","antigravity","simple","cowork"]
 ```
 
 Text-in / text-out: `input` is the source harness's native session text and the result is the target's. Invalid harness names or unparseable input throw a JS `Error`.
@@ -291,6 +293,7 @@ Text-in / text-out: `input` is the source harness's native session text and the 
 | `amp` | `amp threads export` JSON |
 | `antigravity` | JSON dump of the conversation database, protobuf blobs hex-encoded |
 | `simple` | the [Simple](docs/formats/simple.md) interchange JSON document |
+| `cowork` | JSON bundle of the session record, Claude Code transcript, and audit log |
 
 To build the wasm from source instead:
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -53,7 +53,7 @@ mod mcp;
 mod view;
 
 const HARNESSES: &str = "harnesses: claude_code, codex, opencode, pi, campfire, cursor, cursor_desktop, grok, hermes, \
-     amp, antigravity, simple";
+     amp, antigravity, simple, cowork";
 
 #[derive(Parser)]
 #[command(
@@ -759,6 +759,7 @@ mod style {
             HarnessId::Amp => "\x1b[95m",           // bright magenta
             HarnessId::Antigravity => "\x1b[94m",   // bright blue
             HarnessId::Simple => "\x1b[92m",        // bright green
+            HarnessId::Cowork => "\x1b[38;5;208m",  // orange
         }
     }
 }

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -331,6 +331,10 @@ fn chunk_ranges(sizes: &[usize], start: usize, budget: usize) -> Vec<std::ops::R
     chunks
 }
 
+// rmcp's macro emits an `async fn` with no `.await`; clippy 1.98's
+// `unused_async_trait_impl` fires on that generated code, not on ours.
+// `unknown_lints` keeps older clippies quiet about the newer lint name.
+#[allow(unknown_lints, clippy::unused_async_trait_impl)]
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for TxcriptServer {
     fn get_info(&self) -> ServerInfo {

--- a/docs/formats/README.md
+++ b/docs/formats/README.md
@@ -40,6 +40,7 @@ than none.
 | Document | Harness | Parser |
 | --- | --- | --- |
 | [claude-code.md](claude-code.md) | Claude Code (Anthropic) | `src/harness/claude_code.rs` |
+| [cowork.md](cowork.md) | Cowork (Claude desktop app) | `src/harness/cowork.rs` |
 | [codex.md](codex.md) | Codex CLI (OpenAI) | `src/harness/codex.rs` |
 | [opencode.md](opencode.md) | OpenCode (SST) | `src/harness/opencode.rs` |
 | [cursor.md](cursor.md) | Cursor | `src/harness/cursor.rs` |

--- a/docs/formats/cowork.md
+++ b/docs/formats/cowork.md
@@ -1,0 +1,121 @@
+# Cowork
+
+Cowork is the Claude desktop app's local agent mode — the surface through
+which people who never open a terminal run Claude on their own files. Under
+the hood it is Claude Code: the app launches the CLI headlessly through the
+Agent SDK, points it at a private config directory per task, and keeps its
+own session record beside it. Nothing about the format is documented;
+txcript's mapping was reverse-engineered from real sessions on this machine
+(app versions writing CLI 2.1.5 through 2.1.234, January–August 2026) and
+corroborated against the app's own session loader and record validator in
+its bundled JavaScript.
+
+```
+~/Library/Application Support/Claude/local-agent-mode-sessions/   (macOS)
+%APPDATA%\Claude\local-agent-mode-sessions\                       (Windows)
+~/.config/Claude/local-agent-mode-sessions/                        (Linux)
+└── <org-uuid>/<account-uuid>/                 one tree per signed-in account
+    ├── local_<uuid>.json         ── session record (title, cwd, model, times)
+    ├── local_<uuid>/             ── session storage directory
+    │   ├── .claude/              ── the task's private CLAUDE_CONFIG_DIR
+    │   │   └── projects/<encoded-cwd>/
+    │   │       ├── <cliSessionId>.jsonl   ── the conversation (Claude Code JSONL)
+    │   │       └── <cliSessionId>/subagents/*.jsonl   (not carried)
+    │   ├── audit.jsonl           ── Agent SDK stream, HMAC-chained (carried, never written)
+    │   ├── .audit-key            ── encrypted chain key (not carried)
+    │   ├── uploads/, outputs/    ── the user's files (not carried)
+    │   └── .claude/.claude.json, backups/, debug/   (not carried)
+    ├── agent/local_ditto_*.json  ── agent-type sessions, same shape, own subdir
+    └── cowork_settings.json, rpm/, debug/, …        (app state, skipped)
+```
+
+## On disk
+
+The root is the app's data directory plus `local-agent-mode-sessions`,
+overridable wholesale with `$COWORK_SESSIONS_DIR`. The first two levels are
+the organisation and account UUIDs; txcript recognises an account tree by
+both names parsing as UUIDs, which is what separates it from the app's other
+state at the same level (`skills-plugin/`). Inside an account tree a session
+is a `local_*.json` record plus a same-named directory, in the tree itself
+or in its `agent/` subdirectory. Discovery lists the records (the app does
+exactly the same: `readdir`, filter `local_*.json`, validate) and reads each
+one plus a shallow scan of its transcript for metadata.
+
+The record names the Claude Code session under it (`cliSessionId`); the
+transcript is `<storage dir>/.claude/projects/<slug>/<cliSessionId>.jsonl`,
+found under whichever project slug holds it — the slug is Claude Code's
+encoding of the cwd, which for the app's long storage paths is truncated
+with a hash suffix, so it is never reconstructed, only searched. Sessions
+from early 2026 ran inside the app's Linux VM with `cwd: /sessions/<name>`;
+later ones run on the host (`hostLoopMode: true`) with the cwd inside the
+storage directory's `outputs/`. Both shapes load the same way.
+
+`save` writes into the most recently active account tree (the one whose
+newest record is youngest), creating the record, the storage directory with
+its `.claude/projects/<encoded-cwd>/<cliSessionId>.jsonl`, `outputs/` and
+`uploads/`, and `audit.jsonl` only when the body carries one. A root with no
+account tree is an error: the app has never run there, so there is nowhere
+it would look.
+
+## Dissection of a transcript
+
+| Their name | What it is | Maps to |
+|---|---|---|
+| `local_<id>.json` | The app's session record. Required by its validator: `sessionId`, `processName`, `cwd`, `createdAt`, `lastActivityAt`; typed here alongside `cliSessionId`, `model`, `title`, `isArchived`; everything else (`systemPrompt`, `enabledMcpTools`, `egressAllowedDomains`, permission grants, …) passes through untouched | `Meta.id`, `Meta.timestamp` (`createdAt`), `Meta.cwd`, `Meta.title`, `Meta.model` |
+| `<cliSessionId>.jsonl` | Claude Code's session JSONL, exactly as documented in [claude-code.md](claude-code.md): `user`/`assistant` entry lines wrapping Anthropic messages, plus bookkeeping | The conversation, through the `claude_code` codec; `Meta.cli_version` and `Meta.git_branch` come from its envelopes |
+| `queue-operation`, `last-prompt`, `attachment`, `ai-title` lines | Cowork/SDK bookkeeping in the transcript (prompt queueing, deferred-tool and skill listings, the generated title) | Nothing; kept verbatim in the native body |
+| `user` line with `isMeta: true` | Context the app injects for the model — typically the pages of an uploaded PDF rendered as images | A `Role::User` message of `Image` blocks (it is what the model saw) |
+| `<uploaded_files>…</uploaded_files>` prefix | The app's attachment manifest at the head of a prompt | Kept as prompt text: it names the files, it is not boilerplate |
+| `audit.jsonl` | The Agent SDK message stream (`system/init`, `user`, `assistant`, `rate_limit_event`, `result`), every line signed into an HMAC chain | Nothing; carried verbatim, never written |
+
+Tool names are Claude Code's (`Read`, `Edit`, `Bash`, …) plus the app's
+MCP servers (`mcp__workspace__bash`, `mcp__cowork__present_files`,
+`mcp__Claude_in_Chrome__*`), which pass through as `Raw` calls like any
+`mcp__*` tool.
+
+Regeneration writes a record with every required field: `processName` is
+synthesised (`txcript-<8 hex>`), `hostLoopMode` is `true` so the app runs the
+CLI on the host against `cwd`, `initialMessage` is the first prompt's text,
+and `lastActivityAt` the last message's time. The Claude Code transcript is
+stamped with a `cliSessionId` derived as UUIDv5 of the session id, so the
+same conversation always yields the same files. A session id without the
+`local_` prefix gets one — the app lists nothing else.
+
+## Caveats
+
+- The app's record validator silently drops any `local_*.json` it cannot
+  parse, so a missing required field makes a session invisible rather than
+  broken. The required set above comes from the validator itself.
+- The app reads the records once at startup and afterwards tracks only the
+  sessions it creates itself; a session written while it is running appears
+  after a quit and relaunch. There is no per-session launcher or deep link —
+  `claude://resume?session=` imports a Claude Code session into the app's
+  Claude Code surface, not Cowork — so `txcript continue` ends with
+  `open -a Claude`.
+- `audit.jsonl` is a tamper-evident chain keyed through Electron's
+  `safeStorage`; txcript cannot sign entries and does not try. The app
+  treats unsigned and absent logs as valid.
+- `to_common` inherits every Claude Code caveat (local-command envelopes,
+  non-Anthropic stop reasons, tool-result shapes) and adds none. Subagent
+  transcripts are not carried.
+- Thinking blocks in the on-disk transcript can be empty strings with only
+  a signature (the SDK stream redacts them); they load as empty `Thinking`
+  blocks, as they would from Claude Code.
+- Session start is the record's `createdAt`, which precedes the first
+  transcript line by the CLI's start-up time.
+- Regenerating from Common loses what `claude_code` loses; the record's
+  non-conversational state (system prompt, MCP settings, permission grants)
+  is not reconstructed — the app regenerates it on launch.
+
+## References
+
+- Reverse-engineered from sessions under
+  `~/Library/Application Support/Claude/local-agent-mode-sessions`, written
+  by Claude desktop app builds embedding Claude Code 2.1.5–2.1.234.
+- The record schema and loader (`LocalAgentModeSessionManager`) were read
+  from the app bundle (`app.asar`, `.vite/build/index2.chunk-*.js`) of the
+  installed desktop app on 2026-08-20.
+- Authoritative mapping: `src/harness/cowork.rs` (module docs and code) and
+  `tests/integration/cowork.rs` (fixtures shaped like real sessions).
+
+Last verified: 2026-08-20, against src/harness/cowork.rs and real local sessions.

--- a/src/harness/antigravity.rs
+++ b/src/harness/antigravity.rs
@@ -2204,8 +2204,10 @@ fn hex_decode(s: &str) -> std::result::Result<Vec<u8>, String> {
     let bytes = s.as_bytes();
     if bytes.len().is_multiple_of(2) {
         bytes
-            .chunks_exact(2)
-            .map(|pair| Ok((hex_value(pair[0])? << 4) | hex_value(pair[1])?))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|[hi, lo]| Ok((hex_value(*hi)? << 4) | hex_value(*lo)?))
             .collect()
     } else {
         Err("hex string has odd length".to_string())

--- a/src/harness/claude_code.rs
+++ b/src/harness/claude_code.rs
@@ -146,157 +146,174 @@ impl<'de> Deserialize<'de> for Record {
 
 impl Codec for ClaudeCode {
     fn to_common(transcript: &Transcript<Self>) -> Result<Transcript<Common>> {
-        let fallback_ts = transcript.meta.timestamp;
-        let mut messages = Vec::with_capacity(transcript.body.len());
-        // The uuid of the slash command still awaiting its output, so the
-        // `local_command` line that follows pairs to the right call.
-        let mut open_command: Option<&str> = None;
-
-        for record in &transcript.body {
-            let (role, entry) = match record {
-                Record::User(e) => (Role::User, e),
-                Record::Assistant(e) => (Role::Assistant, e),
-                // Newer CLI versions write the same command envelopes on
-                // `system` lines, which have no message wrapper at all.
-                Record::Other(value) => {
-                    messages.extend(system_line_message(value, fallback_ts, &mut open_command));
-                    continue;
-                }
-                // Summaries, titles, snapshots carry no conversational turn.
-                Record::Summary(_) => continue,
-            };
-
-            // Older CLI versions write them as the whole body of a `user`
-            // line; either way they are the user driving the harness, not
-            // conversation, so they become a command call rather than text.
-            let content = match envelope_body(&entry.message.content).and_then(parse_envelope) {
-                Some(envelope) => envelope.into_blocks(
-                    &entry.uuid,
-                    entry.parent_uuid.as_deref(),
-                    &mut open_command,
-                ),
-                None => parse_blocks(&entry.message.content),
-            };
-
-            // An entry whose blocks parse to nothing carries no turn either —
-            // a dropped caveat and an empty body are alike here.
-            if !content.is_empty() {
-                messages.push(Message {
-                    role,
-                    content,
-                    timestamp: entry
-                        .timestamp
-                        .as_deref()
-                        .and_then(parse_ts)
-                        .unwrap_or(fallback_ts),
-                    model: entry.message.model.clone(),
-                    stop_reason: entry.message.stop_reason.as_deref().map(parse_stop_reason),
-                    usage: entry.message.usage.as_ref().and_then(parse_usage),
-                });
-            }
-        }
-
-        Ok(Transcript::new(transcript.meta.clone(), messages))
+        Ok(Transcript::new(
+            transcript.meta.clone(),
+            records_to_messages(&transcript.body, transcript.meta.timestamp),
+        ))
     }
 
     fn from_common(transcript: &Transcript<Common>) -> Result<Transcript<Self>> {
-        let meta = &transcript.meta;
-        let session_id = if meta.id.is_empty() {
-            Uuid::new_v4().to_string()
-        } else {
-            meta.id.clone()
-        };
-        let mut records = Vec::with_capacity(transcript.body.len() + 1);
+        Ok(Transcript::new(
+            transcript.meta.clone(),
+            messages_to_records(&transcript.meta, &transcript.body),
+        ))
+    }
+}
 
-        // Ids of the commands written so far, so their output lands on a
-        // `local_command` line instead of a stray `tool_result`.
-        let mut command_ids = std::collections::HashSet::new();
-        // Every call the transcript makes. A lone result naming none of them
-        // cannot replay as a `tool_result` — the API rejects an id it never
-        // issued — so it takes the `local_command` line too, which preserves
-        // the text and still loads.
-        let called: std::collections::HashSet<&str> = transcript
-            .body
-            .iter()
-            .flat_map(|msg| &msg.content)
-            .filter_map(|block| match block {
-                Block::ToolUse { id, .. } => Some(id.as_str()),
-                _ => None,
-            })
-            .collect();
-        let mut parent_uuid: Option<String> = None;
-        for (i, msg) in transcript.body.iter().enumerate() {
-            let uuid = entry_uuid(&session_id, i);
+/// The conversation carried by a sequence of records; `fallback_ts` dates
+/// entries that carry no timestamp of their own. Shared with harnesses that
+/// embed Claude Code's JSONL (Cowork).
+pub(crate) fn records_to_messages(records: &[Record], fallback_ts: DateTime<Utc>) -> Vec<Message> {
+    let mut messages = Vec::with_capacity(records.len());
+    // The uuid of the slash command still awaiting its output, so the
+    // `local_command` line that follows pairs to the right call.
+    let mut open_command: Option<&str> = None;
 
-            // Local-command turns go back as the native envelopes, not as
-            // message blocks: `tool_use` on a user turn is not a shape the
-            // Anthropic API accepts, so a resumed session would fail to load.
-            if msg.role == Role::User
-                && let Some(record) = local_command_record(
-                    msg,
-                    &mut command_ids,
-                    &called,
-                    &uuid,
-                    parent_uuid.as_deref(),
-                    &session_id,
-                    meta,
-                )
-            {
-                records.push(record);
-                parent_uuid = Some(uuid);
+    for record in records {
+        let (role, entry) = match record {
+            Record::User(e) => (Role::User, e),
+            Record::Assistant(e) => (Role::Assistant, e),
+            // Newer CLI versions write the same command envelopes on
+            // `system` lines, which have no message wrapper at all.
+            Record::Other(value) => {
+                messages.extend(system_line_message(value, fallback_ts, &mut open_command));
                 continue;
             }
+            // Summaries, titles, snapshots carry no conversational turn.
+            Record::Summary(_) => continue,
+        };
 
-            let api = ApiMessage {
-                role: Some(role_str(msg.role).to_string()),
-                content: serialize_blocks(&msg.content),
-                model: msg.model.clone(),
-                stop_reason: msg.stop_reason.as_ref().map(stop_reason_str),
-                usage: msg.usage.as_ref().map(serialize_usage),
-                extra: Map::new(),
-            };
-            let entry = EntryLine {
-                parent_uuid: parent_uuid.clone(),
-                uuid: uuid.clone(),
-                timestamp: Some(msg.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true)),
-                session_id: Some(session_id.clone()),
-                cwd: meta.cwd.clone(),
-                git_branch: meta.git_branch.clone(),
-                version: meta.cli_version.clone(),
-                message: api,
-                extra: Map::new(),
-            };
-            records.push(match msg.role {
-                Role::User => Record::User(entry),
-                Role::Assistant => Record::Assistant(entry),
+        // Older CLI versions write them as the whole body of a `user`
+        // line; either way they are the user driving the harness, not
+        // conversation, so they become a command call rather than text.
+        let content = match envelope_body(&entry.message.content).and_then(parse_envelope) {
+            Some(envelope) => {
+                envelope.into_blocks(&entry.uuid, entry.parent_uuid.as_deref(), &mut open_command)
+            }
+            None => parse_blocks(&entry.message.content),
+        };
+
+        // An entry whose blocks parse to nothing carries no turn either —
+        // a dropped caveat and an empty body are alike here.
+        if !content.is_empty() {
+            messages.push(Message {
+                role,
+                content,
+                timestamp: entry
+                    .timestamp
+                    .as_deref()
+                    .and_then(parse_ts)
+                    .unwrap_or(fallback_ts),
+                model: entry.message.model.clone(),
+                stop_reason: entry.message.stop_reason.as_deref().map(parse_stop_reason),
+                usage: entry.message.usage.as_ref().and_then(parse_usage),
             });
-            parent_uuid = Some(uuid);
         }
-
-        // A leading summary gives `claude --resume` a friendly title — but its
-        // `leafUuid` must name a real user/assistant line in this file. Claude
-        // Code resolves a session by walking to the leaf the summaries point
-        // at; a summary whose leafUuid matches nothing leaves it with no leaf
-        // and the whole session reads as missing ("No conversation found with
-        // session ID"). A `local_command` line is not an eligible leaf either,
-        // so anchor to the last real turn.
-        if let Some(title) = meta.title.as_deref().filter(|t| !t.is_empty())
-            && let Some(leaf) = records.iter().rev().find_map(|record| match record {
-                Record::User(entry) | Record::Assistant(entry) => Some(entry.uuid.clone()),
-                _ => None,
-            })
-        {
-            records.insert(
-                0,
-                Record::Summary(SummaryLine {
-                    summary: title.to_string(),
-                    extra: Map::from_iter([("leafUuid".into(), Value::String(leaf))]),
-                }),
-            );
-        }
-
-        Ok(Transcript::new(meta.clone(), records))
     }
+
+    messages
+}
+
+/// The native records for a canonical conversation: one entry line per
+/// message (local-command turns as their envelopes), a linear `parentUuid`
+/// chain, and a leading summary line when `meta.title` is set. `meta.id` is
+/// the `sessionId` stamped on every line (a fresh UUID when empty). Shared
+/// with harnesses that embed Claude Code's JSONL (Cowork).
+pub(crate) fn messages_to_records(meta: &Meta, messages: &[Message]) -> Vec<Record> {
+    let session_id = if meta.id.is_empty() {
+        Uuid::new_v4().to_string()
+    } else {
+        meta.id.clone()
+    };
+    let mut records = Vec::with_capacity(messages.len() + 1);
+
+    // Ids of the commands written so far, so their output lands on a
+    // `local_command` line instead of a stray `tool_result`.
+    let mut command_ids = std::collections::HashSet::new();
+    // Every call the transcript makes. A lone result naming none of them
+    // cannot replay as a `tool_result` — the API rejects an id it never
+    // issued — so it takes the `local_command` line too, which preserves
+    // the text and still loads.
+    let called: std::collections::HashSet<&str> = messages
+        .iter()
+        .flat_map(|msg| &msg.content)
+        .filter_map(|block| match block {
+            Block::ToolUse { id, .. } => Some(id.as_str()),
+            _ => None,
+        })
+        .collect();
+    let mut parent_uuid: Option<String> = None;
+    for (i, msg) in messages.iter().enumerate() {
+        let uuid = entry_uuid(&session_id, i);
+
+        // Local-command turns go back as the native envelopes, not as
+        // message blocks: `tool_use` on a user turn is not a shape the
+        // Anthropic API accepts, so a resumed session would fail to load.
+        if msg.role == Role::User
+            && let Some(record) = local_command_record(
+                msg,
+                &mut command_ids,
+                &called,
+                &uuid,
+                parent_uuid.as_deref(),
+                &session_id,
+                meta,
+            )
+        {
+            records.push(record);
+            parent_uuid = Some(uuid);
+            continue;
+        }
+
+        let api = ApiMessage {
+            role: Some(role_str(msg.role).to_string()),
+            content: serialize_blocks(&msg.content),
+            model: msg.model.clone(),
+            stop_reason: msg.stop_reason.as_ref().map(stop_reason_str),
+            usage: msg.usage.as_ref().map(serialize_usage),
+            extra: Map::new(),
+        };
+        let entry = EntryLine {
+            parent_uuid: parent_uuid.clone(),
+            uuid: uuid.clone(),
+            timestamp: Some(msg.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true)),
+            session_id: Some(session_id.clone()),
+            cwd: meta.cwd.clone(),
+            git_branch: meta.git_branch.clone(),
+            version: meta.cli_version.clone(),
+            message: api,
+            extra: Map::new(),
+        };
+        records.push(match msg.role {
+            Role::User => Record::User(entry),
+            Role::Assistant => Record::Assistant(entry),
+        });
+        parent_uuid = Some(uuid);
+    }
+
+    // A leading summary gives `claude --resume` a friendly title — but its
+    // `leafUuid` must name a real user/assistant line in this file. Claude
+    // Code resolves a session by walking to the leaf the summaries point
+    // at; a summary whose leafUuid matches nothing leaves it with no leaf
+    // and the whole session reads as missing ("No conversation found with
+    // session ID"). A `local_command` line is not an eligible leaf either,
+    // so anchor to the last real turn.
+    if let Some(title) = meta.title.as_deref().filter(|t| !t.is_empty())
+        && let Some(leaf) = records.iter().rev().find_map(|record| match record {
+            Record::User(entry) | Record::Assistant(entry) => Some(entry.uuid.clone()),
+            _ => None,
+        })
+    {
+        records.insert(
+            0,
+            Record::Summary(SummaryLine {
+                summary: title.to_string(),
+                extra: Map::from_iter([("leafUuid".into(), Value::String(leaf))]),
+            }),
+        );
+    }
+
+    records
 }
 
 impl TextCodec for ClaudeCode {
@@ -1005,7 +1022,7 @@ fn entry_uuid(session_id: &str, index: usize) -> String {
 
 /// Extract session metadata from the records. `id` is left empty when no
 /// `sessionId` is present; a [`Store`] fills it from the filename.
-fn meta_from_records(records: &[Record]) -> Meta {
+pub(crate) fn meta_from_records(records: &[Record]) -> Meta {
     let mut meta = Meta {
         id: String::new(),
         timestamp: Utc::now(),
@@ -1142,7 +1159,7 @@ impl From<MetaEntryLine> for EntryLine {
 /// preserved [`Record::Other`] `Value`: an unknown or non-string tag, or the
 /// rare known-tag line whose body fails its typed schema. Invalid JSON
 /// parses to `None` and is skipped, exactly as under [`jsonl::parse`].
-fn record_from_line(line: &str) -> Option<Record> {
+pub(crate) fn record_from_line(line: &str) -> Option<Record> {
     let other = || serde_json::from_str::<Value>(line).ok().map(Record::Other);
     match serde_json::from_str::<jsonl::TypeProbe>(line) {
         // A failed probe isn't necessarily junk: a non-string `type` also
@@ -1191,7 +1208,7 @@ fn scan_line(line: &str) -> Option<Record> {
 
 /// [`meta_from_records`] over a shallow scan of the raw text — equivalent to
 /// `from_text(text)?.meta`, but discovery never builds message payloads.
-fn meta_from_text(text: &str) -> Meta {
+pub(crate) fn meta_from_text(text: &str) -> Meta {
     let records: Vec<Record> = text
         .lines()
         .filter(|line| !line.trim().is_empty())
@@ -1203,7 +1220,7 @@ fn meta_from_text(text: &str) -> Meta {
 /// Claude's project-dir encoding: every `/` and `.` becomes `-`. Windows
 /// cwds encode the same way with `\` and the drive `:` also mapped
 /// (`C:\Users\x` → `C--Users-x`).
-fn encode_project_dir(path: &str) -> String {
+pub(crate) fn encode_project_dir(path: &str) -> String {
     path.chars()
         .map(|c| {
             if matches!(c, '/' | '.' | '\\' | ':') {
@@ -1215,7 +1232,7 @@ fn encode_project_dir(path: &str) -> String {
         .collect()
 }
 
-fn file_fingerprint(path: &Path) -> String {
+pub(crate) fn file_fingerprint(path: &Path) -> String {
     match fs::metadata(path) {
         // An unreadable file has no fingerprint.
         Err(_) => String::new(),

--- a/src/harness/cowork.rs
+++ b/src/harness/cowork.rs
@@ -1,0 +1,596 @@
+//! Cowork — the Claude desktop app's local agent mode:
+//! `<app data>/Claude/local-agent-mode-sessions/<org>/<account>/local_<uuid>.json`.
+//!
+//! Cowork runs Claude Code headlessly (through the Agent SDK) with a private
+//! `CLAUDE_CONFIG_DIR` per task, and keeps its own session record next to it.
+//! One session is therefore three carriers:
+//!
+//! - `local_<id>.json` — the app's session record (**header** here): the
+//!   `local_…` session id, `cliSessionId` (the Claude Code session under it),
+//!   `cwd`, `createdAt`/`lastActivityAt` (epoch ms), `model`, `title`,
+//!   `isArchived`, the rendered system prompt, MCP/plugin settings. The app
+//!   lists sessions by reading these; a record its validator rejects is
+//!   silently skipped. Required: `sessionId`, `processName`, `cwd`,
+//!   `createdAt`, `lastActivityAt`.
+//! - `local_<id>/.claude/projects/<encoded-cwd>/<cliSessionId>.jsonl` — the
+//!   conversation, in Claude Code's own JSONL (**transcript**). The app
+//!   locates it by `cliSessionId` under any project slug and resumes it with
+//!   the CLI; txcript reuses the `claude_code` codec on it verbatim, so every
+//!   Claude Code record kind, tool, and quirk applies unchanged. Cowork-only
+//!   records (`queue-operation`, `last-prompt`, `attachment`, `ai-title`)
+//!   ride through as [`Record::Other`].
+//! - `local_<id>/audit.jsonl` — the Agent SDK stream as the app saw it
+//!   (**audit**): an append-only, HMAC-chained log whose key lives in
+//!   Electron's `safeStorage`. It is carried verbatim for native round trips
+//!   and never regenerated — the app tolerates its absence (unsigned and
+//!   missing logs are both valid states for it).
+//!
+//! Not carried: the per-task `.claude/.claude.json` config cache and its
+//! backups, `uploads/` and `outputs/` (the user's files), subagent
+//! transcripts under `<cliSessionId>/subagents/`, and `debug/`.
+//!
+//! `to_common` is the Claude Code mapping over the transcript; the header
+//! supplies `Meta` (id, title, cwd, model, start time). `from_common`
+//! regenerates the transcript through the Claude Code codec under a
+//! deterministic `cliSessionId` (`UUIDv5` of the session id) and a header
+//! carrying every field the app requires; the session id is given a `local_`
+//! prefix when it lacks one, which is the one way `Meta` can change through
+//! Common. The audit log is left empty. Everything `claude_code` cannot
+//! represent (its module docs) is lost here too.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Number, Value};
+use uuid::Uuid;
+
+use crate::common::{Block, Message, Meta, Role};
+use crate::error::{Error, Result};
+use crate::harness::claude_code::{self, Record};
+use crate::harness::jsonl;
+use crate::transcript::{Codec, Common, Discovered, Harness, Saved, Store, TextCodec, Transcript};
+
+/// The Cowork harness marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Cowork;
+
+impl Harness for Cowork {
+    const NAME: &'static str = "cowork";
+    type Body = CoworkSession;
+}
+
+// ── native records ─────────────────────────────────────────────────────
+
+/// Faithful in-memory representation of one Cowork session: its app record,
+/// its Claude Code transcript, and its audit log.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CoworkSession {
+    pub header: Header,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transcript: Vec<Record>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub audit: Vec<Value>,
+}
+
+/// The app's session record (`local_<id>.json`). Only the fields the codec
+/// reads or writes are typed; the rest (system prompt, MCP configuration,
+/// permission grants, …) flatten into `extra` untouched.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Header {
+    #[serde(rename = "sessionId", default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(
+        rename = "cliSessionId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cli_session_id: Option<String>,
+    #[serde(
+        rename = "processName",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub process_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    /// Epoch milliseconds.
+    #[serde(rename = "createdAt", default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<Number>,
+    /// Epoch milliseconds.
+    #[serde(
+        rename = "lastActivityAt",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub last_activity_at: Option<Number>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(
+        rename = "isArchived",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub is_archived: Option<bool>,
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
+}
+
+// ── codec ──────────────────────────────────────────────────────────────
+
+impl Codec for Cowork {
+    fn to_common(transcript: &Transcript<Self>) -> Result<Transcript<Common>> {
+        Ok(Transcript::new(
+            transcript.meta.clone(),
+            claude_code::records_to_messages(
+                &transcript.body.transcript,
+                transcript.meta.timestamp,
+            ),
+        ))
+    }
+
+    fn from_common(transcript: &Transcript<Common>) -> Result<Transcript<Self>> {
+        let (meta, body) = body_from_messages(&transcript.meta, &transcript.body);
+        Ok(Transcript::new(meta, body))
+    }
+}
+
+impl TextCodec for Cowork {
+    fn from_text(text: &str) -> Result<Transcript<Self>> {
+        let body: CoworkSession = serde_json::from_str(text)?;
+        let meta = meta_from_body(&body);
+        Ok(Transcript::new(meta, body))
+    }
+
+    fn to_text(transcript: &Transcript<Self>) -> Result<String> {
+        Ok(serde_json::to_string_pretty(&transcript.body)?)
+    }
+}
+
+/// The native session for a canonical conversation, plus the `Meta` it
+/// answers to (the session id gains Cowork's `local_` prefix if missing).
+fn body_from_messages(meta: &Meta, messages: &[Message]) -> (Meta, CoworkSession) {
+    let session_id = session_id_for(&meta.id);
+    let cli_session_id = cli_session_id_for(&session_id);
+
+    // The transcript is Claude Code's, stamped with the CLI session id —
+    // that is the id the app resumes by, not the `local_…` one.
+    let mut cli_meta = meta.clone();
+    cli_meta.id.clone_from(&cli_session_id);
+    let transcript = claude_code::messages_to_records(&cli_meta, messages);
+
+    let created_at = meta.timestamp.timestamp_millis();
+    let last_activity_at = messages
+        .iter()
+        .map(|m| m.timestamp.timestamp_millis())
+        .max()
+        .map_or(created_at, |last| last.max(created_at));
+    let initial_message = messages
+        .iter()
+        .find(|m| m.role == Role::User)
+        .and_then(|m| {
+            m.content.iter().find_map(|block| match block {
+                Block::Text { text } => Some(text.clone()),
+                // Only text opens a prompt in the app's record.
+                Block::Thinking { .. }
+                | Block::ToolUse { .. }
+                | Block::ToolResult { .. }
+                | Block::Image { .. } => None,
+            })
+        });
+
+    let mut extra = Map::new();
+    // The app runs the CLI on the host against `cwd` (rather than inside its
+    // Linux VM, whose cwd would be `/sessions/<processName>`).
+    extra.insert("hostLoopMode".into(), Value::Bool(true));
+    if let Some(text) = initial_message {
+        extra.insert("initialMessage".into(), Value::String(text));
+    }
+    let header = Header {
+        session_id: Some(session_id.clone()),
+        cli_session_id: Some(cli_session_id.clone()),
+        // Required by the app's record validator; natively the VM/process
+        // name. Derived, so conversion stays a pure function of the input.
+        process_name: Some(format!("txcript-{}", &cli_session_id[..8])),
+        cwd: Some(meta.cwd.clone().unwrap_or_default()),
+        created_at: Some(created_at.into()),
+        last_activity_at: Some(last_activity_at.into()),
+        model: meta.model.clone(),
+        title: meta.title.clone(),
+        is_archived: Some(false),
+        extra,
+    };
+
+    let mut out_meta = meta.clone();
+    out_meta.id = session_id;
+    (
+        out_meta,
+        CoworkSession {
+            header,
+            transcript,
+            audit: Vec::new(),
+        },
+    )
+}
+
+/// Cowork session ids are `local_<uuid>`; the app lists only files with that
+/// prefix. An empty id mints a fresh one.
+fn session_id_for(id: &str) -> String {
+    if id.is_empty() {
+        format!("local_{}", Uuid::new_v4())
+    } else if id.starts_with("local_") {
+        id.to_string()
+    } else {
+        format!("local_{id}")
+    }
+}
+
+/// Deterministic Claude Code session id for a Cowork session, so
+/// `from_common` is a pure function of the transcript.
+fn cli_session_id_for(session_id: &str) -> String {
+    const NS: Uuid = Uuid::from_bytes([
+        0x3c, 0x7a, 0xe1, 0x52, 0x8b, 0x4d, 0x4e, 0x0f, 0x9a, 0x61, 0x2d, 0xc8, 0x7f, 0x15, 0xb9,
+        0x04,
+    ]);
+    Uuid::new_v5(&NS, session_id.as_bytes()).to_string()
+}
+
+// ── metadata ───────────────────────────────────────────────────────────
+
+/// `Meta` from the session: the header is authoritative for what it carries
+/// (id, start time, cwd, title, model); the transcript supplies the rest
+/// (CLI version, git branch) and backfills any header gap.
+fn meta_from_body(body: &CoworkSession) -> Meta {
+    meta_from_parts(
+        &body.header,
+        claude_code::meta_from_records(&body.transcript),
+    )
+}
+
+fn meta_from_parts(header: &Header, transcript: Meta) -> Meta {
+    let non_empty = |s: &Option<String>| s.clone().filter(|v| !v.trim().is_empty());
+    Meta {
+        id: header.session_id.clone().unwrap_or_default(),
+        timestamp: header
+            .created_at
+            .as_ref()
+            .and_then(epoch_millis)
+            .unwrap_or(transcript.timestamp),
+        cwd: non_empty(&header.cwd).or(transcript.cwd),
+        git_branch: transcript.git_branch,
+        title: non_empty(&header.title).or(transcript.title),
+        cli_version: transcript.cli_version,
+        model: non_empty(&header.model).or(transcript.model),
+    }
+}
+
+/// Epoch milliseconds as written by `Date.now()`; a fractional value is
+/// truncated to the millisecond.
+#[allow(clippy::cast_possible_truncation)] // guarded: finite, in i64 range
+fn epoch_millis(n: &Number) -> Option<DateTime<Utc>> {
+    let ms = n.as_i64().or_else(|| {
+        n.as_f64()
+            .filter(|f| f.is_finite() && f.abs() < 9.0e15)
+            .map(|f| f as i64)
+    })?;
+    DateTime::from_timestamp_millis(ms)
+}
+
+// ── store ──────────────────────────────────────────────────────────────
+
+/// Reads and writes Cowork sessions under the app's
+/// `local-agent-mode-sessions` directory.
+///
+/// The directory holds one `<org-uuid>/<account-uuid>/` tree per signed-in
+/// account; discovery walks them all, and `save` writes into the most
+/// recently active one.
+#[derive(Debug, Clone)]
+pub struct CoworkStore {
+    pub root: PathBuf,
+}
+
+impl CoworkStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// The app's sessions root: `$COWORK_SESSIONS_DIR` when set, else
+    /// `local-agent-mode-sessions` under the Claude desktop app's data
+    /// directory (`~/Library/Application Support/Claude` on macOS,
+    /// `%APPDATA%\Claude` on Windows, `~/.config/Claude` elsewhere).
+    #[must_use]
+    pub fn default_root() -> Option<Self> {
+        if let Some(dir) = std::env::var_os("COWORK_SESSIONS_DIR").filter(|v| !v.is_empty()) {
+            return Some(Self::new(PathBuf::from(dir)));
+        }
+        let home = super::home_dir()?;
+        let app_data = if cfg!(target_os = "macos") {
+            home.join("Library/Application Support/Claude")
+        } else if cfg!(windows) {
+            std::env::var_os("APPDATA")
+                .filter(|v| !v.is_empty())
+                .map_or_else(|| home.join("AppData").join("Roaming"), PathBuf::from)
+                .join("Claude")
+        } else {
+            home.join(".config/Claude")
+        };
+        Some(Self::new(app_data.join("local-agent-mode-sessions")))
+    }
+
+    /// Every `<org>/<account>/` directory under the root. Both levels are
+    /// UUID-named; that is what separates account trees from the app's
+    /// other state (`skills-plugin/`, …) at the same level.
+    fn account_dirs(&self) -> Vec<PathBuf> {
+        let uuid_dirs = |dir: &Path| -> Vec<PathBuf> {
+            fs::read_dir(dir)
+                .into_iter()
+                .flatten()
+                .flatten()
+                .map(|e| e.path())
+                .filter(|p| {
+                    p.is_dir()
+                        && p.file_name()
+                            .and_then(|n| n.to_str())
+                            .is_some_and(|n| Uuid::parse_str(n).is_ok())
+                })
+                .collect()
+        };
+        let mut out: Vec<PathBuf> = uuid_dirs(&self.root)
+            .iter()
+            .flat_map(|org| uuid_dirs(org))
+            .collect();
+        out.sort();
+        out
+    }
+
+    /// The account tree `save` writes into: the one whose newest session
+    /// record is most recent (the account the app is using), else the only
+    /// one there is.
+    fn active_account_dir(&self) -> Result<PathBuf> {
+        let newest_record = |dir: &Path| {
+            session_files(dir)
+                .iter()
+                .filter_map(|p| fs::metadata(p).and_then(|m| m.modified()).ok())
+                .max()
+        };
+        self.account_dirs()
+            .into_iter()
+            .map(|dir| (newest_record(&dir), dir))
+            .max()
+            .map(|(_, dir)| dir)
+            .ok_or_else(|| Error::Unconvertible {
+                harness: Cowork::NAME,
+                detail: format!(
+                    "no Cowork account directory under {}; open Cowork once so the app \
+                     creates its <org>/<account> tree",
+                    self.root.display()
+                ),
+            })
+    }
+
+    /// The transcript file for a session record, if the header names a CLI
+    /// session and the file exists under any project slug.
+    fn transcript_path(session_dir: &Path, header: &Header) -> Option<PathBuf> {
+        let cli = header.cli_session_id.as_deref()?;
+        super::checked_id_component(Cowork::NAME, cli).ok()?;
+        let projects = session_dir.join(".claude").join("projects");
+        fs::read_dir(projects)
+            .ok()?
+            .flatten()
+            .map(|slug| slug.path().join(format!("{cli}.jsonl")))
+            .find(|p| p.is_file())
+    }
+}
+
+/// The session records in one directory, plus those of its `agent/`
+/// subdirectory (where the app keeps its agent-type sessions).
+fn session_files(dir: &Path) -> Vec<PathBuf> {
+    let records = |dir: &Path| -> Vec<PathBuf> {
+        fs::read_dir(dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.is_file() && is_session_record(p))
+            .collect()
+    };
+    let mut out = records(dir);
+    out.extend(records(&dir.join("agent")));
+    out.sort();
+    out
+}
+
+/// Whether a path is named like an app session record: `local_*.json`.
+fn is_session_record(path: &Path) -> bool {
+    path.file_stem()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with("local_"))
+        && path.extension().is_some_and(|e| e == "json")
+}
+
+/// The session's storage directory: the record's path without `.json`.
+fn session_dir(record: &Path) -> PathBuf {
+    record.with_extension("")
+}
+
+fn read_header(path: &Path) -> Result<Header> {
+    let text = fs::read_to_string(path)?;
+    let header: Header = serde_json::from_str(&text)?;
+    if header.session_id.is_none() {
+        return Err(Error::Malformed {
+            harness: Cowork::NAME,
+            detail: format!("{} carries no sessionId", path.display()),
+        });
+    }
+    Ok(header)
+}
+
+impl Store for CoworkStore {
+    type H = Cowork;
+    type Ref = PathBuf;
+
+    fn discover(&self) -> Result<Vec<Discovered<PathBuf>>> {
+        // No root (Cowork never ran here) means no sessions.
+        if !self.root.is_dir() {
+            return Ok(Vec::new());
+        }
+        Ok(self
+            .account_dirs()
+            .iter()
+            .flat_map(|account| session_files(account))
+            .filter_map(|path| {
+                // A record the app would reject, or that fails to read, is
+                // skipped, not fatal. Discovery meta comes from the header
+                // plus Claude Code's shallow scan of the transcript — the
+                // same fields a full load would yield.
+                let header = read_header(&path).ok()?;
+                let transcript_meta = Self::transcript_path(&session_dir(&path), &header)
+                    .and_then(|p| fs::read_to_string(p).ok())
+                    .map_or_else(
+                        || claude_code::meta_from_records(&[]),
+                        |text| claude_code::meta_from_text(&text),
+                    );
+                let mut meta = meta_from_parts(&header, transcript_meta);
+                if meta.id.is_empty() {
+                    meta.id = jsonl::file_id(&path);
+                }
+                Some(Discovered {
+                    meta,
+                    reference: path,
+                })
+            })
+            .collect())
+    }
+
+    fn load(&self, reference: &PathBuf) -> Result<Transcript<Cowork>> {
+        let header = read_header(reference)?;
+        let dir = session_dir(reference);
+        let transcript = Self::transcript_path(&dir, &header)
+            .and_then(|p| fs::read_to_string(p).ok())
+            .map(|text| {
+                text.lines()
+                    .filter(|line| !line.trim().is_empty())
+                    .filter_map(claude_code::record_from_line)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let audit = fs::read_to_string(dir.join("audit.jsonl"))
+            .map(|text| jsonl::parse(&text))
+            .unwrap_or_default();
+        let body = CoworkSession {
+            header,
+            transcript,
+            audit,
+        };
+        let mut meta = meta_from_body(&body);
+        if meta.id.is_empty() {
+            meta.id = jsonl::file_id(reference);
+        }
+        Ok(Transcript::new(meta, body))
+    }
+
+    fn save(&self, transcript: &Transcript<Cowork>) -> Result<Saved<PathBuf>> {
+        let body = &transcript.body;
+        let id = body
+            .header
+            .session_id
+            .clone()
+            .filter(|id| !id.is_empty())
+            .unwrap_or_else(|| transcript.meta.id.clone());
+        super::checked_id_component(Cowork::NAME, &id)?;
+        let account = self.active_account_dir()?;
+        let record = account.join(format!("{id}.json"));
+        let dir = account.join(&id);
+
+        // The CLI session the app will resume: the header's, or the one the
+        // codec would have derived.
+        let cli = body
+            .header
+            .cli_session_id
+            .clone()
+            .unwrap_or_else(|| cli_session_id_for(&id));
+        super::checked_id_component(Cowork::NAME, &cli)?;
+        let cwd = body
+            .header
+            .cwd
+            .clone()
+            .or_else(|| transcript.meta.cwd.clone())
+            .unwrap_or_default();
+        let project_dir = dir
+            .join(".claude")
+            .join("projects")
+            .join(claude_code::encode_project_dir(&cwd));
+        fs::create_dir_all(&project_dir)?;
+        // The app's cwd for host sessions; also where it expects uploads.
+        fs::create_dir_all(dir.join("outputs"))?;
+        fs::create_dir_all(dir.join("uploads"))?;
+
+        fs::write(
+            project_dir.join(format!("{cli}.jsonl")),
+            jsonl::render(&body.transcript)?,
+        )?;
+        if !body.audit.is_empty() {
+            fs::write(dir.join("audit.jsonl"), jsonl::render(&body.audit)?)?;
+        }
+        fs::write(&record, serde_json::to_string(&body.header)?)?;
+        Ok(Saved {
+            id,
+            reference: record,
+        })
+    }
+
+    /// Removes the session record and its storage directory. Guarded on
+    /// shape and containment: the reference must be a `local_*.json` record
+    /// resolving to `<root>/<org>/<account>/[agent/]<id>.json`, so a stale or
+    /// foreign reference never removes an unrelated tree.
+    fn delete(&self, reference: &PathBuf) -> Result<()> {
+        if !(is_session_record(reference) && reference.is_file()) {
+            return Err(Error::Malformed {
+                harness: Cowork::NAME,
+                detail: format!("not a Cowork session record: {}", reference.display()),
+            });
+        }
+        let canon = reference.canonicalize()?;
+        let root = self.root.canonicalize()?;
+        let contained = canon.strip_prefix(&root).is_ok_and(|rest| {
+            let parts: Vec<_> = rest.components().collect();
+            parts.len() == 3
+                || (parts.len() == 4 && parts[2].as_os_str() == std::ffi::OsStr::new("agent"))
+        });
+        if !contained {
+            return Err(Error::Malformed {
+                harness: Cowork::NAME,
+                detail: format!(
+                    "refusing to delete outside the sessions root: {}",
+                    reference.display()
+                ),
+            });
+        }
+        let dir = session_dir(&canon);
+        if dir.is_dir() {
+            fs::remove_dir_all(&dir)?;
+        }
+        Ok(fs::remove_file(canon)?)
+    }
+
+    fn fingerprints(&self, refs: &[PathBuf]) -> Result<HashMap<String, String>> {
+        let mut out = HashMap::with_capacity(refs.len());
+        for record in refs {
+            // The transcript is what grows; the record changes with it, so
+            // it stands in when the transcript can't be found.
+            let file = read_header(record)
+                .ok()
+                .and_then(|h| Self::transcript_path(&session_dir(record), &h))
+                .unwrap_or_else(|| record.clone());
+            out.insert(
+                record.to_string_lossy().into_owned(),
+                claude_code::file_fingerprint(&file),
+            );
+        }
+        Ok(out)
+    }
+}

--- a/src/harness/cursor.rs
+++ b/src/harness/cursor.rs
@@ -1874,7 +1874,7 @@ fn md5_hex(data: &[u8]) -> String {
         *slot = ((f64::sin((i + 1) as f64).abs() * 4_294_967_296.0).floor()) as u32;
     }
 
-    for chunk in msg.chunks_exact(64) {
+    for chunk in msg.as_chunks::<64>().0 {
         let mut m = [0u32; 16];
         for (i, word) in m.iter_mut().enumerate() {
             let start = i * 4;
@@ -2009,7 +2009,7 @@ fn sha256(data: &[u8]) -> [u8; 32] {
     }
     msg.extend(bit_len.to_be_bytes());
 
-    for chunk in msg.chunks_exact(64) {
+    for chunk in msg.as_chunks::<64>().0 {
         let mut w = [0u32; 64];
         for (i, word) in w.iter_mut().take(16).enumerate() {
             let start = i * 4;
@@ -2081,8 +2081,10 @@ fn hex_decode(s: &str) -> std::result::Result<Vec<u8>, String> {
     let bytes = s.as_bytes();
     if bytes.len().is_multiple_of(2) {
         bytes
-            .chunks_exact(2)
-            .map(|pair| Ok((hex_value(pair[0])? << 4) | hex_value(pair[1])?))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|[hi, lo]| Ok((hex_value(*hi)? << 4) | hex_value(*lo)?))
             .collect()
     } else {
         Err("hex string has odd length".to_string())

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -10,6 +10,7 @@ pub mod antigravity;
 pub mod campfire;
 pub mod claude_code;
 pub mod codex;
+pub mod cowork;
 pub mod cursor;
 pub mod cursor_desktop;
 pub mod grok;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Typed conversion for coding-agent session transcripts.
 //!
-//! Claude Code, Codex, `OpenCode`, pi, Campfire, Cursor, Grok, Hermes, Amp,
-//! and Antigravity record similar conversation data in different on-disk
+//! Claude Code, Cowork, Codex, `OpenCode`, pi, Campfire, Cursor, Grok, Hermes,
+//! Amp, and Antigravity record similar conversation data in different on-disk
 //! formats. This crate maps each format through [`Transcript<Common>`] and
 //! converts with [`convert::<A, B>`](convert): `A` -> [`Common`] -> `B`.
 //!

--- a/src/local.rs
+++ b/src/local.rs
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Utc};
 
 use crate::common::Meta;
-use crate::harness::{amp, antigravity, campfire, claude_code, codex, cursor, grok, pi};
+use crate::harness::{amp, antigravity, campfire, claude_code, codex, cowork, cursor, grok, pi};
 
 #[cfg(feature = "hermes")]
 use crate::harness::hermes;
@@ -110,6 +110,12 @@ pub fn discover_with(mut on_store: impl FnMut(HarnessId, usize)) -> Vec<Session>
     scan(
         HarnessId::Antigravity,
         antigravity::AntigravityStore::default_root(),
+        &mut out,
+    );
+    on_store(HarnessId::Cowork, out.len());
+    scan(
+        HarnessId::Cowork,
+        cowork::CoworkStore::default_root(),
         &mut out,
     );
 
@@ -205,6 +211,7 @@ impl Session {
             (HarnessId::Antigravity, Locator::Path(p)) => {
                 go(antigravity::AntigravityStore::default_root(), p)
             }
+            (HarnessId::Cowork, Locator::Path(p)) => go(cowork::CoworkStore::default_root(), p),
             #[cfg(feature = "hermes")]
             (HarnessId::Hermes, Locator::Id(id)) => {
                 hermes::Hermes::to_common(&required(hermes::HermesStore::default_root())?.load(id)?)
@@ -249,6 +256,7 @@ impl Session {
             (HarnessId::Antigravity, Locator::Path(p)) => {
                 go(antigravity::AntigravityStore::default_root(), p)
             }
+            (HarnessId::Cowork, Locator::Path(p)) => go(cowork::CoworkStore::default_root(), p),
             // Errors: the Hermes store is read-only.
             #[cfg(feature = "hermes")]
             (HarnessId::Hermes, Locator::Id(id)) => {
@@ -390,6 +398,13 @@ pub fn write(
             common,
             |s| s.root,
         ),
+        HarnessId::Cowork => go(
+            cowork::CoworkStore::default_root(),
+            cowork::CoworkStore::new,
+            root,
+            common,
+            |s| s.root,
+        ),
         // Simple is an interchange *input*: documents are handed to txcript
         // directly (a file, stdin, the WASM text API) rather than managed in
         // a directory of its own, so there is nowhere to write one back to.
@@ -487,6 +502,12 @@ pub fn resume_command(harness: HarnessId, id: &str) -> (String, Vec<String>) {
             HarnessId::Hermes => ("hermes".into(), vec!["--resume".into(), id]),
             HarnessId::Amp => ("amp".into(), vec!["threads".into(), "continue".into(), id]),
             HarnessId::Antigravity => ("agy".into(), vec![format!("--conversation={id}")]),
+            // No per-session entry point: the Claude desktop app lists the
+            // session under Cowork once it restarts or rescans.
+            HarnessId::Cowork if cfg!(target_os = "macos") => {
+                ("open".into(), vec!["-a".into(), "Claude".into()])
+            }
+            HarnessId::Cowork => ("Claude".into(), Vec::new()),
             // Unreachable in practice: Simple sessions are neither discovered
             // nor written, so nothing resumes one. There is no native app.
             HarnessId::Simple => ("txcript".into(), Vec::new()),

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -244,10 +244,11 @@ pub enum HarnessId {
     Amp,
     Antigravity,
     Simple,
+    Cowork,
 }
 
 impl HarnessId {
-    pub const ALL: [HarnessId; 12] = [
+    pub const ALL: [HarnessId; 13] = [
         HarnessId::ClaudeCode,
         HarnessId::Codex,
         HarnessId::OpenCode,
@@ -260,6 +261,7 @@ impl HarnessId {
         HarnessId::Amp,
         HarnessId::Antigravity,
         HarnessId::Simple,
+        HarnessId::Cowork,
     ];
 
     /// The stable lowercase name, matching the corresponding [`Harness::NAME`].
@@ -278,6 +280,7 @@ impl HarnessId {
             HarnessId::Amp => "amp",
             HarnessId::Antigravity => "antigravity",
             HarnessId::Simple => "simple",
+            HarnessId::Cowork => "cowork",
         }
     }
 }
@@ -312,6 +315,9 @@ impl FromStr for HarnessId {
                 Ok(HarnessId::Antigravity)
             }
             "simple" | "simple_json" | "simple-json" => Ok(HarnessId::Simple),
+            "cowork" | "claude_cowork" | "claude-cowork" | "claude_desktop" | "claude-desktop" => {
+                Ok(HarnessId::Cowork)
+            }
             other => Err(crate::error::Error::UnknownHarness(other.to_string())),
         }
     }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -14,8 +14,8 @@ use wasm_bindgen::prelude::*;
 
 use crate::common;
 use crate::harness::{
-    amp, antigravity, campfire, claude_code, codex, cursor, cursor_desktop, grok, hermes, opencode,
-    pi, simple,
+    amp, antigravity, campfire, claude_code, codex, cowork, cursor, cursor_desktop, grok, hermes,
+    opencode, pi, simple,
 };
 use crate::transcript::{Codec, Common, HarnessId, TextCodec, Transcript};
 
@@ -27,10 +27,12 @@ use crate::transcript::{Codec, Common, HarnessId, TextCodec, Transcript};
 /// opencode, the JSON bundle of the session directory for grok, the
 /// `hermes sessions export` JSON object for hermes, the thread JSON document
 /// for amp, the JSON dump of the conversation database for antigravity, the
-/// interchange JSON document for simple); `from`/`to` are harness names
-/// (`"claude_code"`, `"codex"`, `"opencode"`, `"pi"`, `"campfire"`,
+/// interchange JSON document for simple, the JSON bundle of the session
+/// record, transcript and audit log for cowork); `from`/`to` are harness
+/// names (`"claude_code"`, `"codex"`, `"opencode"`, `"pi"`, `"campfire"`,
 /// `"cursor"`, `"cursor_desktop"`, `"grok"`, `"hermes"`, `"amp"`,
-/// `"antigravity"`, `"simple"`). Returns the target harness's native text.
+/// `"antigravity"`, `"simple"`, `"cowork"`). Returns the target harness's
+/// native text.
 #[wasm_bindgen]
 pub fn convert(input: &str, from: &str, to: &str) -> Result<String, JsError> {
     parse_harness(from)
@@ -205,6 +207,7 @@ fn parse_to_common(harness: HarnessId, text: &str) -> crate::Result<Transcript<C
         HarnessId::Amp => go::<amp::Amp>(text),
         HarnessId::Antigravity => go::<antigravity::Antigravity>(text),
         HarnessId::Simple => go::<simple::Simple>(text),
+        HarnessId::Cowork => go::<cowork::Cowork>(text),
     }
 }
 
@@ -225,6 +228,7 @@ fn render_from_common(harness: HarnessId, common: &Transcript<Common>) -> crate:
         HarnessId::Amp => go::<amp::Amp>(common),
         HarnessId::Antigravity => go::<antigravity::Antigravity>(common),
         HarnessId::Simple => go::<simple::Simple>(common),
+        HarnessId::Cowork => go::<cowork::Cowork>(common),
     }
 }
 

--- a/tests/integration/cowork.rs
+++ b/tests/integration/cowork.rs
@@ -1,0 +1,674 @@
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
+//! Cowork harness tests: Store round trip, metadata discovery, Common
+//! extraction, codec fixpoints, and format-specific behavior.
+
+use chrono::{DateTime, Utc};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use txcript::common::{
+    Block, ImageSource, Message, Meta, Role, StopReason, Tool, ToolOutput, Usage,
+};
+use txcript::harness::claude_code::Record;
+use txcript::harness::cowork::{Cowork, CoworkStore};
+use txcript::{Codec, Store, TextCodec, Transcript};
+
+const ORG: &str = "f00cbda9-1bc5-46fe-adb4-ea0be3ce03cb";
+const ACCOUNT: &str = "3f389f6c-c5fe-4c2d-92bf-8f61bfa2bf6c";
+const SESSION_ID: &str = "local_5a7d4a86-4628-4182-a822-292dc8a1df9d";
+const CLI_ID: &str = "c9258e92-ad74-42f8-b67c-c9186dc46931";
+const CWD: &str = "/repo";
+
+fn ts(s: &str) -> DateTime<Utc> {
+    s.parse().unwrap()
+}
+
+fn png_image_block() -> Block {
+    Block::Image {
+        source: ImageSource {
+            source_type: "base64".into(),
+            media_type: "image/png".into(),
+            data: "UE5HYnl0ZXM=".into(),
+        },
+    }
+}
+
+/// The app's session record, shaped like a real `local_*.json` (the
+/// conversation never lives here — only settings and bookkeeping).
+fn header_json() -> String {
+    json!({
+        "sessionId": SESSION_ID,
+        "processName": "pensive-youthful-mendel",
+        "cliSessionId": CLI_ID,
+        "cwd": CWD,
+        "createdAt": 1_783_372_201_477_i64,
+        "lastActivityAt": 1_783_372_232_997_i64,
+        "model": "claude-opus-4-8",
+        "isArchived": false,
+        "title": "Security deposit refund terms",
+        "vmProcessName": "pensive-youthful-mendel",
+        "hostLoopMode": true,
+        "initialMessage": "what are the terms for: refund of security deposit.",
+        "chromePermissionMode": "skip_all_permission_checks",
+        "userSelectedFolders": [],
+        "enabledMcpTools": {"mcp__workspace__bash": true},
+        "slashCommands": ["compact", "context"],
+        "systemPrompt": "Claude is powering Cowork mode…",
+        "egressAllowedDomains": ["github.com"],
+        "accountName": "Me",
+        "emailAddress": "me@example.com",
+    })
+    .to_string()
+}
+
+/// The Claude Code transcript Cowork keeps under its per-task config dir,
+/// mirroring the real sample's record kinds: queue/prompt bookkeeping, the
+/// `<uploaded_files>` prompt with an image, thinking + a Read call, the
+/// tool result, the `isMeta` page images, deferred-tool attachments, and
+/// an `ai-title` line — every non-message kind must survive untouched.
+fn transcript_jsonl() -> String {
+    let env = |uuid: &str, parent: Option<&str>, at: &str| {
+        json!({
+            "uuid": uuid,
+            "parentUuid": parent,
+            "timestamp": at,
+            "sessionId": CLI_ID,
+            "cwd": CWD,
+            "gitBranch": "HEAD",
+            "version": "2.1.177",
+            "isSidechain": false,
+            "userType": "external",
+            "entrypoint": "sdk-ts",
+        })
+    };
+    let line = |kind: &str, mut envelope: Value, rest: Value| {
+        let obj = envelope.as_object_mut().unwrap();
+        obj.insert("type".into(), Value::String(kind.into()));
+        for (k, v) in rest.as_object().unwrap() {
+            obj.insert(k.clone(), v.clone());
+        }
+        envelope.to_string() + "\n"
+    };
+    [
+        json!({"type": "queue-operation", "operation": "enqueue",
+            "timestamp": "2026-07-06T21:10:05.420Z", "sessionId": CLI_ID}).to_string() + "\n",
+        line("user", env("u1", None, "2026-07-06T21:10:05.652Z"), json!({
+            "promptId": "p1", "permissionMode": "bypassPermissions", "promptSource": "sdk",
+            "message": {"role": "user", "content": [
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "UE5HYnl0ZXM="}},
+                {"type": "text", "text": "<uploaded_files>\n<file><file_path>terms.pdf</file_path></file>\n</uploaded_files>\n\nwhat are the terms for: refund of security deposit."},
+            ]}})),
+        json!({"type": "attachment", "uuid": "a1", "parentUuid": "u1", "sessionId": CLI_ID,
+            "timestamp": "2026-07-06T21:10:05.700Z", "cwd": CWD, "gitBranch": "HEAD",
+            "version": "2.1.177", "isSidechain": false, "userType": "external", "entrypoint": "sdk-ts",
+            "attachment": {"type": "deferred_tools_delta", "addedNames": ["WebSearch"], "addedLines": []}}).to_string() + "\n",
+        line("assistant", env("a2", Some("u1"), "2026-07-06T21:10:11.900Z"), json!({
+            "requestId": "req_1",
+            "message": {"role": "assistant", "model": "claude-opus-4-8", "id": "msg_1",
+                "content": [{"type": "thinking", "thinking": "Read the PDF first.", "signature": "sig1"}],
+                "stop_reason": null, "usage": {"input_tokens": 10, "output_tokens": 2}}})),
+        line("assistant", env("a3", Some("a2"), "2026-07-06T21:10:16.300Z"), json!({
+            "requestId": "req_1",
+            "message": {"role": "assistant", "model": "claude-opus-4-8", "id": "msg_1",
+                "content": [{"type": "tool_use", "id": "toolu_1", "name": "Read",
+                             "input": {"file_path": "/repo/uploads/terms.pdf"}}],
+                "stop_reason": null, "usage": {"input_tokens": 10, "output_tokens": 20}}})),
+        line("user", env("u4", Some("a3"), "2026-07-06T21:10:19.186Z"), json!({
+            "promptId": "p1", "sourceToolAssistantUUID": "a3",
+            "toolUseResult": {"type": "pdf", "file": {"filePath": "/repo/uploads/terms.pdf", "numPages": 6}},
+            "message": {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_1",
+                 "content": [{"type": "text", "text": "PDF with 6 pages (rendered as images)"}]}]}})),
+        line("user", env("u5", Some("u4"), "2026-07-06T21:10:19.185Z"), json!({
+            "promptId": "p1", "isMeta": true,
+            "message": {"role": "user", "content": [
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "UE5HYnl0ZXM="}},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "UE5HYnl0ZXM="}},
+            ]}})),
+        line("assistant", env("a6", Some("u5"), "2026-07-06T21:10:32.970Z"), json!({
+            "requestId": "req_2",
+            "message": {"role": "assistant", "model": "claude-opus-4-8", "id": "msg_2",
+                "content": [{"type": "text", "text": "The deposit is refunded within 30 days."}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 300, "output_tokens": 40, "cache_read_input_tokens": 100}}})),
+        json!({"type": "last-prompt", "leafUuid": "a6", "sessionId": CLI_ID}).to_string() + "\n",
+        json!({"type": "ai-title", "aiTitle": "Security deposit refund terms", "sessionId": CLI_ID}).to_string() + "\n",
+    ]
+    .concat()
+}
+
+/// A slice of the Agent SDK stream the app appends to `audit.jsonl`, with
+/// its HMAC chain fields; opaque to txcript, carried verbatim.
+fn audit_jsonl() -> String {
+    [
+        json!({"type": "system", "subtype": "init", "cwd": CWD, "session_id": CLI_ID,
+            "uuid": "x1", "_audit_timestamp": "2026-07-06T21:10:05.667Z", "_audit_hmac": "00ab"}),
+        json!({"type": "result", "subtype": "success", "session_id": CLI_ID, "num_turns": 3,
+            "uuid": "x2", "_audit_timestamp": "2026-07-06T21:10:33.003Z", "_audit_hmac": "00cd"}),
+    ]
+    .iter()
+    .map(|v| v.to_string() + "\n")
+    .collect()
+}
+
+/// Lay the fixture out exactly as the app does under `<root>/<org>/<account>/`
+/// and return the session record path (the Store's reference).
+fn write_fixture(root: &std::path::Path) -> std::path::PathBuf {
+    let account = root.join(ORG).join(ACCOUNT);
+    let dir = account.join(SESSION_ID);
+    let project = dir.join(".claude").join("projects").join("-repo");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(dir.join("outputs")).unwrap();
+    std::fs::create_dir_all(dir.join("uploads")).unwrap();
+    std::fs::write(project.join(format!("{CLI_ID}.jsonl")), transcript_jsonl()).unwrap();
+    // A subagent transcript sits beside the main one and is not a session.
+    let sub = project.join(CLI_ID).join("subagents");
+    std::fs::create_dir_all(&sub).unwrap();
+    std::fs::write(sub.join("agent-1.jsonl"), "{\"type\":\"user\"}\n").unwrap();
+    std::fs::write(dir.join("audit.jsonl"), audit_jsonl()).unwrap();
+    std::fs::write(dir.join(".audit-key"), "v1:opaque").unwrap();
+    let record = account.join(format!("{SESSION_ID}.json"));
+    std::fs::write(&record, header_json()).unwrap();
+    record
+}
+
+#[test]
+fn store_round_trip_is_lossless_on_disk() {
+    let src = TempDir::new().unwrap();
+    let record = write_fixture(src.path());
+    let store = CoworkStore::new(src.path());
+    let first = store.load(&record).unwrap();
+
+    // Cowork-only and bookkeeping records are carried, untouched.
+    let other = |kind: &str| {
+        first.body.transcript.iter().any(|r| {
+            matches!(
+                r,
+                Record::Other(v) if v.get("type").and_then(Value::as_str) == Some(kind)
+            )
+        })
+    };
+    assert!(other("queue-operation"));
+    assert!(other("attachment"));
+    assert!(other("last-prompt"));
+    assert!(other("ai-title"));
+    assert_eq!(first.body.audit.len(), 2);
+    assert_eq!(
+        first.body.header.extra.get("chromePermissionMode"),
+        Some(&json!("skip_all_permission_checks"))
+    );
+
+    // A fresh root with an (empty) account tree, as on a machine where the
+    // app has run but holds no sessions yet.
+    let dst = TempDir::new().unwrap();
+    let other_account = dst.path().join(ORG).join(ACCOUNT);
+    std::fs::create_dir_all(&other_account).unwrap();
+    let dst_store = CoworkStore::new(dst.path());
+    let saved = dst_store.save(&first).unwrap();
+
+    // The app's layout: record beside a same-named directory holding the
+    // per-task Claude Code config dir with the transcript under the
+    // Claude-encoded cwd.
+    assert_eq!(saved.id, SESSION_ID);
+    assert_eq!(
+        saved.reference,
+        other_account.join(format!("{SESSION_ID}.json"))
+    );
+    let transcript = other_account
+        .join(SESSION_ID)
+        .join(".claude/projects/-repo")
+        .join(format!("{CLI_ID}.jsonl"));
+    assert!(
+        transcript.is_file(),
+        "transcript at {}",
+        transcript.display()
+    );
+    assert!(other_account.join(SESSION_ID).join("audit.jsonl").is_file());
+    assert!(other_account.join(SESSION_ID).join("outputs").is_dir());
+
+    let second = dst_store.load(&saved.reference).unwrap();
+    assert_eq!(first, second);
+}
+
+#[test]
+fn discover_extracts_metadata() {
+    let root = TempDir::new().unwrap();
+    let record = write_fixture(root.path());
+    let store = CoworkStore::new(root.path());
+    let found = store.discover().unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].reference, record);
+    let meta = &found[0].meta;
+    assert_eq!(meta.id, SESSION_ID);
+    assert_eq!(meta.cwd.as_deref(), Some(CWD));
+    assert_eq!(meta.title.as_deref(), Some("Security deposit refund terms"));
+    assert_eq!(meta.model.as_deref(), Some("claude-opus-4-8"));
+    // Start time is the app's createdAt, not the first transcript line.
+    assert_eq!(meta.timestamp, ts("2026-07-06T21:10:01.477Z"));
+    // CLI version and branch only exist in the transcript.
+    assert_eq!(meta.cli_version.as_deref(), Some("2.1.177"));
+    assert_eq!(meta.git_branch.as_deref(), Some("HEAD"));
+
+    // Discovery and load agree on every field.
+    assert_eq!(store.load(&record).unwrap().meta, *meta);
+}
+
+#[test]
+fn to_common_extracts_the_claude_code_conversation() {
+    let root = TempDir::new().unwrap();
+    let record = write_fixture(root.path());
+    let store = CoworkStore::new(root.path());
+    let common = Cowork::to_common(&store.load(&record).unwrap()).unwrap();
+    let msgs = &common.body;
+
+    // queue-operation, attachment, last-prompt and ai-title carry no turn.
+    assert_eq!(msgs.len(), 6);
+
+    // The prompt keeps Cowork's <uploaded_files> manifest: it is what the
+    // model saw and names the attachment, not boilerplate.
+    assert_eq!(msgs[0].role, Role::User);
+    assert_eq!(msgs[0].content.len(), 2);
+    assert_eq!(msgs[0].content[0], png_image_block());
+    assert!(matches!(
+        &msgs[0].content[1],
+        Block::Text { text } if text.starts_with("<uploaded_files>")
+    ));
+    assert_eq!(msgs[0].timestamp, ts("2026-07-06T21:10:05.652Z"));
+
+    assert_eq!(
+        msgs[1].content,
+        vec![Block::Thinking {
+            text: "Read the PDF first.".into(),
+            signature: Some("sig1".into()),
+            encrypted: None,
+        }]
+    );
+    assert_eq!(
+        msgs[2].content,
+        vec![Block::ToolUse {
+            id: "toolu_1".into(),
+            tool: Tool::Read {
+                file_path: "/repo/uploads/terms.pdf".into(),
+                offset: None,
+                limit: None,
+            },
+        }]
+    );
+    assert_eq!(msgs[2].model.as_deref(), Some("claude-opus-4-8"));
+
+    // Claude's block-array result stays structured.
+    assert_eq!(
+        msgs[3].content,
+        vec![Block::ToolResult {
+            tool_use_id: "toolu_1".into(),
+            content: ToolOutput::Json(json!([
+                {"type": "text", "text": "PDF with 6 pages (rendered as images)"}
+            ])),
+            is_error: false,
+        }]
+    );
+
+    // The rendered PDF pages (an isMeta user line) are model context.
+    assert_eq!(msgs[4].role, Role::User);
+    assert_eq!(msgs[4].content, vec![png_image_block(), png_image_block()]);
+
+    assert_eq!(msgs[5].stop_reason, Some(StopReason::EndTurn));
+    assert_eq!(
+        msgs[5].usage,
+        Some(Usage {
+            input_tokens: 300,
+            output_tokens: 40,
+            cache_read_input_tokens: Some(100),
+            cache_creation_input_tokens: None,
+        })
+    );
+}
+
+/// A Common transcript at Cowork's native granularity — Claude Code's, with
+/// a `local_` session id and a millisecond start time.
+#[allow(clippy::too_many_lines)]
+fn representable_common() -> Transcript<txcript::Common> {
+    let meta = Meta {
+        id: SESSION_ID.into(),
+        timestamp: ts("2026-07-06T21:10:01.477Z"),
+        cwd: Some(CWD.into()),
+        git_branch: Some("main".into()),
+        title: Some("Security deposit refund terms".into()),
+        cli_version: Some("2.1.177".into()),
+        model: Some("claude-opus-4-8".into()),
+    };
+    let model = || Some("claude-opus-4-8".to_string());
+    let body = vec![
+        Message {
+            role: Role::User,
+            content: vec![
+                Block::Text {
+                    text: "what are the terms for: refund of security deposit.".into(),
+                },
+                png_image_block(),
+            ],
+            timestamp: ts("2026-07-06T21:10:05.652Z"),
+            model: None,
+            stop_reason: None,
+            usage: None,
+        },
+        Message {
+            role: Role::Assistant,
+            content: vec![
+                Block::Thinking {
+                    text: "Read the PDF first.".into(),
+                    signature: Some("sig1".into()),
+                    encrypted: None,
+                },
+                Block::ToolUse {
+                    id: "toolu_1".into(),
+                    tool: Tool::Read {
+                        file_path: "/repo/uploads/terms.pdf".into(),
+                        offset: None,
+                        limit: None,
+                    },
+                },
+            ],
+            timestamp: ts("2026-07-06T21:10:16.300Z"),
+            model: model(),
+            stop_reason: Some(StopReason::ToolUse),
+            usage: Some(Usage {
+                input_tokens: 10,
+                output_tokens: 20,
+                cache_read_input_tokens: None,
+                cache_creation_input_tokens: None,
+            }),
+        },
+        Message {
+            role: Role::User,
+            content: vec![Block::ToolResult {
+                tool_use_id: "toolu_1".into(),
+                content: ToolOutput::Json(json!([{"type": "text", "text": "6 pages"}])),
+                is_error: false,
+            }],
+            timestamp: ts("2026-07-06T21:10:19.186Z"),
+            model: None,
+            stop_reason: None,
+            usage: None,
+        },
+        Message {
+            role: Role::Assistant,
+            content: vec![Block::ToolUse {
+                id: "toolu_2".into(),
+                tool: Tool::Raw {
+                    tool_name: "mcp__workspace__bash".into(),
+                    input: json!({"command": "ls uploads"}),
+                },
+            }],
+            timestamp: ts("2026-07-06T21:10:20.000Z"),
+            model: model(),
+            stop_reason: Some(StopReason::ToolUse),
+            usage: None,
+        },
+        Message {
+            role: Role::User,
+            content: vec![Block::ToolResult {
+                tool_use_id: "toolu_2".into(),
+                content: ToolOutput::Text("ls: sandbox denied".into()),
+                is_error: true,
+            }],
+            timestamp: ts("2026-07-06T21:10:21.000Z"),
+            model: None,
+            stop_reason: None,
+            usage: None,
+        },
+        Message {
+            role: Role::Assistant,
+            content: vec![Block::Text {
+                text: "The deposit is refunded within 30 days.".into(),
+            }],
+            timestamp: ts("2026-07-06T21:10:32.970Z"),
+            model: model(),
+            stop_reason: Some(StopReason::EndTurn),
+            usage: Some(Usage {
+                input_tokens: 300,
+                output_tokens: 40,
+                cache_read_input_tokens: Some(100),
+                cache_creation_input_tokens: Some(5),
+            }),
+        },
+    ];
+    Transcript::new(meta, body)
+}
+
+#[test]
+fn codec_fixpoint_through_common_loses_nothing() {
+    let common = representable_common();
+    let native = Cowork::from_common(&common).unwrap();
+    let back = Cowork::to_common(&native).unwrap();
+    assert_eq!(back.meta, common.meta);
+    assert_eq!(back.body, common.body);
+}
+
+#[test]
+fn from_common_is_deterministic() {
+    let common = representable_common();
+    let a = Cowork::to_text(&Cowork::from_common(&common).unwrap()).unwrap();
+    let b = Cowork::to_text(&Cowork::from_common(&common).unwrap()).unwrap();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn from_common_regenerates_the_app_record_and_the_cli_transcript() {
+    let native = Cowork::from_common(&representable_common()).unwrap();
+    let header = &native.body.header;
+
+    // Every field the app's record validator requires, plus the ones it
+    // shows in its session list.
+    assert_eq!(header.session_id.as_deref(), Some(SESSION_ID));
+    assert!(
+        header
+            .process_name
+            .as_deref()
+            .is_some_and(|p| !p.is_empty())
+    );
+    assert_eq!(header.cwd.as_deref(), Some(CWD));
+    assert_eq!(
+        header
+            .created_at
+            .as_ref()
+            .and_then(serde_json::Number::as_i64),
+        Some(1_783_372_201_477)
+    );
+    assert_eq!(
+        header
+            .last_activity_at
+            .as_ref()
+            .and_then(serde_json::Number::as_i64),
+        Some(1_783_372_232_970),
+        "last activity is the final message's time"
+    );
+    assert_eq!(
+        header.title.as_deref(),
+        Some("Security deposit refund terms")
+    );
+    assert_eq!(header.model.as_deref(), Some("claude-opus-4-8"));
+    assert_eq!(header.is_archived, Some(false));
+    assert_eq!(header.extra.get("hostLoopMode"), Some(&json!(true)));
+    assert_eq!(
+        header.extra.get("initialMessage"),
+        Some(&json!(
+            "what are the terms for: refund of security deposit."
+        ))
+    );
+
+    // The transcript is Claude Code's, stamped with the CLI session id the
+    // app resumes by — a UUID derived from the Cowork id.
+    let cli = header.cli_session_id.clone().unwrap();
+    assert!(uuid::Uuid::parse_str(&cli).is_ok());
+    assert_ne!(cli, SESSION_ID);
+    let stamped: Vec<Option<&str>> = native
+        .body
+        .transcript
+        .iter()
+        .filter_map(|r| match r {
+            Record::User(e) | Record::Assistant(e) => Some(e.session_id.as_deref()),
+            // Summary and other lines carry no sessionId.
+            Record::Summary(_) | Record::Other(_) => None,
+        })
+        .collect();
+    assert_eq!(stamped.len(), 6);
+    assert!(stamped.iter().all(|id| *id == Some(cli.as_str())));
+
+    // The audit log is the app's own tamper-evident record; never forged.
+    assert!(native.body.audit.is_empty());
+}
+
+#[test]
+fn from_common_prefixes_foreign_ids_with_local() {
+    let mut common = representable_common();
+    common.meta.id = "11111111-1111-4111-8111-111111111111".into();
+    let native = Cowork::from_common(&common).unwrap();
+    assert_eq!(native.meta.id, "local_11111111-1111-4111-8111-111111111111");
+    assert_eq!(
+        native.body.header.session_id.as_deref(),
+        Some("local_11111111-1111-4111-8111-111111111111")
+    );
+    // Everything but the id survives the prefixing.
+    let back = Cowork::to_common(&native).unwrap();
+    assert_eq!(back.body, common.body);
+}
+
+#[test]
+fn text_codec_round_trips_the_session_bundle() {
+    let root = TempDir::new().unwrap();
+    let record = write_fixture(root.path());
+    let store = CoworkStore::new(root.path());
+    let loaded = store.load(&record).unwrap();
+    let text = Cowork::to_text(&loaded).unwrap();
+    let parsed = Cowork::from_text(&text).unwrap();
+    assert_eq!(parsed, loaded);
+}
+
+#[test]
+fn discovery_skips_non_account_trees_and_invalid_records() {
+    let root = TempDir::new().unwrap();
+    write_fixture(root.path());
+    let account = root.path().join(ORG).join(ACCOUNT);
+
+    // The app's other state at the same levels.
+    std::fs::create_dir_all(root.path().join("skills-plugin").join(ACCOUNT).join(ORG)).unwrap();
+    std::fs::write(
+        root.path()
+            .join("skills-plugin")
+            .join(ACCOUNT)
+            .join(ORG)
+            .join("local_x.json"),
+        header_json(),
+    )
+    .unwrap();
+    std::fs::write(account.join("cowork_settings.json"), "{}").unwrap();
+    std::fs::write(account.join("remote-session-spaces.json"), "{}").unwrap();
+    // A record the app would reject (no sessionId) and one that isn't JSON.
+    std::fs::write(account.join("local_broken.json"), "{\"cwd\": \"/x\"}").unwrap();
+    std::fs::write(account.join("local_junk.json"), "not json").unwrap();
+
+    let store = CoworkStore::new(root.path());
+    let found = store.discover().unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].meta.id, SESSION_ID);
+}
+
+#[test]
+fn discovery_includes_agent_sessions_and_missing_root_is_empty() {
+    let root = TempDir::new().unwrap();
+    write_fixture(root.path());
+    let agent = root.path().join(ORG).join(ACCOUNT).join("agent");
+    std::fs::create_dir_all(&agent).unwrap();
+    let mut header: Value = serde_json::from_str(&header_json()).unwrap();
+    header["sessionId"] = json!("local_ditto_3f389f6c");
+    header["title"] = json!("Ditto");
+    std::fs::write(agent.join("local_ditto_3f389f6c.json"), header.to_string()).unwrap();
+
+    let store = CoworkStore::new(root.path());
+    let mut titles: Vec<String> = store
+        .discover()
+        .unwrap()
+        .iter()
+        .filter_map(|d| d.meta.title.clone())
+        .collect();
+    titles.sort();
+    assert_eq!(titles, vec!["Ditto", "Security deposit refund terms"]);
+
+    assert!(
+        CoworkStore::new(root.path().join("nowhere"))
+            .discover()
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn save_picks_the_most_recently_active_account() {
+    let root = TempDir::new().unwrap();
+    let stale = root.path().join(ORG).join(ACCOUNT);
+    let active = root
+        .path()
+        .join("0d9f1b4a-7c1e-4e3b-9a6d-2f5c8b1e7d20")
+        .join("5e2c7a9b-3d4f-4b8a-8c1d-9e0f1a2b3c4d");
+    std::fs::create_dir_all(&stale).unwrap();
+    std::fs::create_dir_all(&active).unwrap();
+    std::fs::write(stale.join("local_old.json"), header_json()).unwrap();
+    let old = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+    std::fs::File::open(stale.join("local_old.json"))
+        .unwrap()
+        .set_modified(old)
+        .unwrap();
+    std::fs::write(active.join("local_new.json"), header_json()).unwrap();
+
+    let store = CoworkStore::new(root.path());
+    let saved = store
+        .save(&Cowork::from_common(&representable_common()).unwrap())
+        .unwrap();
+    assert_eq!(saved.reference, active.join(format!("{SESSION_ID}.json")));
+
+    // Without any account tree there is nowhere the app would look.
+    let empty = TempDir::new().unwrap();
+    assert!(
+        CoworkStore::new(empty.path())
+            .save(&Cowork::from_common(&representable_common()).unwrap())
+            .is_err()
+    );
+}
+
+#[test]
+fn delete_removes_record_and_storage_dir_inside_the_root_only() {
+    let root = TempDir::new().unwrap();
+    let record = write_fixture(root.path());
+    let store = CoworkStore::new(root.path());
+    let dir = record.with_extension("");
+    assert!(dir.is_dir());
+    store.delete(&record).unwrap();
+    assert!(!record.exists());
+    assert!(!dir.exists());
+
+    // A look-alike outside the root is refused, and left alone.
+    let elsewhere = TempDir::new().unwrap();
+    let foreign = write_fixture(elsewhere.path());
+    assert!(store.delete(&foreign).is_err());
+    assert!(foreign.is_file());
+}
+
+#[test]
+fn fingerprints_follow_the_transcript() {
+    let root = TempDir::new().unwrap();
+    let record = write_fixture(root.path());
+    let store = CoworkStore::new(root.path());
+    let before = store.fingerprints(std::slice::from_ref(&record)).unwrap();
+    let transcript = record
+        .with_extension("")
+        .join(".claude/projects/-repo")
+        .join(format!("{CLI_ID}.jsonl"));
+    let mut text = std::fs::read_to_string(&transcript).unwrap();
+    text.push_str("{\"type\":\"queue-operation\"}\n");
+    std::fs::write(&transcript, text).unwrap();
+    let after = store.fingerprints(std::slice::from_ref(&record)).unwrap();
+    let key = record.to_string_lossy().into_owned();
+    assert_ne!(before[&key], after[&key]);
+    assert!(!after[&key].is_empty());
+}

--- a/tests/integration/cowork.rs
+++ b/tests/integration/cowork.rs
@@ -615,7 +615,10 @@ fn save_picks_the_most_recently_active_account() {
     std::fs::create_dir_all(&active).unwrap();
     std::fs::write(stale.join("local_old.json"), header_json()).unwrap();
     let old = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
-    std::fs::File::open(stale.join("local_old.json"))
+    // Write access: Windows refuses to touch the mtime of a read-only handle.
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(stale.join("local_old.json"))
         .unwrap()
         .set_modified(old)
         .unwrap();

--- a/tests/integration/cross_harness.rs
+++ b/tests/integration/cross_harness.rs
@@ -6,8 +6,8 @@
 use chrono::{DateTime, Utc};
 use txcript::common;
 use txcript::harness::{
-    amp, antigravity, campfire, claude_code, codex, cursor, cursor_desktop, grok, hermes, opencode,
-    pi, simple,
+    amp, antigravity, campfire, claude_code, codex, cowork, cursor, cursor_desktop, grok, hermes,
+    opencode, pi, simple,
 };
 use txcript::{Codec, Common, Transcript, convert};
 
@@ -213,8 +213,15 @@ fn conversation_survives_every_hop() {
         "simple"
     );
 
+    let cowork = convert::<simple::Simple, cowork::Cowork>(&simple).unwrap();
+    assert_eq!(
+        signature(&cowork::Cowork::to_common(&cowork).unwrap()),
+        expected,
+        "cowork"
+    );
+
     // And all the way back to Claude.
-    let round = convert::<simple::Simple, claude_code::ClaudeCode>(&simple).unwrap();
+    let round = convert::<cowork::Cowork, claude_code::ClaudeCode>(&cowork).unwrap();
     assert_eq!(
         signature(&claude_code::ClaudeCode::to_common(&round).unwrap()),
         expected,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -10,6 +10,7 @@ mod amp;
 mod antigravity;
 mod claude_code;
 mod codex;
+mod cowork;
 mod cross_harness;
 mod cursor;
 mod cursor_desktop;

--- a/tests/integration/properties.rs
+++ b/tests/integration/properties.rs
@@ -18,8 +18,8 @@ use proptest::test_runner::TestCaseError;
 use serde_json::json;
 use txcript::common::{Block, Message, Meta, Role, Tool, ToolOutput};
 use txcript::harness::{
-    amp, antigravity, campfire, claude_code, codex, cursor, cursor_desktop, grok, hermes, opencode,
-    pi, simple,
+    amp, antigravity, campfire, claude_code, codex, cowork, cursor, cursor_desktop, grok, hermes,
+    opencode, pi, simple,
 };
 use txcript::{Codec, Common, Transcript};
 
@@ -266,5 +266,6 @@ proptest! {
         assert_fixpoint::<amp::Amp>("amp", &common)?;
         assert_fixpoint::<antigravity::Antigravity>("antigravity", &common)?;
         assert_fixpoint::<simple::Simple>("simple", &common)?;
+        assert_fixpoint::<cowork::Cowork>("cowork", &common)?;
     }
 }


### PR DESCRIPTION
## Summary

Cowork (the Claude desktop app's local agent mode) runs Claude Code headlessly under a per-task `CLAUDE_CONFIG_DIR` and keeps an app-side session record beside it. This adds it as the 13th harness: discovery over every Cowork session on the machine, conversion in both directions, and the format write-up.

A session is three carriers under `<Claude app data>/local-agent-mode-sessions/<org>/<account>/`:

- `local_<id>.json` — the record the app lists. Its bundled validator requires `sessionId`, `processName`, `cwd`, `createdAt`, `lastActivityAt` and silently skips anything failing it; typed here with the metadata fields, everything else passes through.
- `local_<id>/.claude/projects/<slug>/<cliSessionId>.jsonl` — plain Claude Code JSONL. The codec delegates to `claude_code`, whose record↔message helpers become `pub(crate)` for it.
- `audit.jsonl` — the HMAC-chained Agent SDK stream. Carried verbatim on native round trips, never written.

`from_common` regenerates the record with every required field (`processName` synthesised, `hostLoopMode: true`, `initialMessage`, `lastActivityAt`), a UUIDv5 `cliSessionId`, and a `local_` prefix on foreign ids. The store walks `<org-uuid>/<account-uuid>/` trees (and `agent/`) and writes into the most recently active one.

Docs: `docs/formats/cowork.md`, README rows, and a cowork section in the harness skill's pattern catalog.

## Verification

- 13 integration tests (store round trip incl. unmodeled records and the audit log, discovery meta, Common extraction, codec fixpoint, determinism, record regeneration, id prefixing, account selection, delete containment, fingerprints); cross-harness hop and proptest fixpoint extended.
- `cargo test --workspace --all-features`, `--no-default-features`, pedantic clippy, fmt: clean.
- Corpus check against every local session: 1,025 existing sessions identical on `main` and this branch (`Meta`, message/block counts, body hash); 23 Cowork sessions (CLI 2.1.5–2.1.234) read with 0 failures, 0 panics, 51 ms total.
- Resume both ways: Cowork → Claude Code via `claude --resume` (headless from an unrelated cwd, and the TUI); Claude Code → Cowork opened and continued in the desktop app.

## Known losses

Whatever `claude_code` loses; subagent transcripts; the record's non-conversational state (system prompt, MCP config), which the app regenerates. Sessions written while the app is open appear after a relaunch; there is no per-session deep link, so `continue` ends with `open -a Claude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)