### PR TITLE
feat: add `txcript export` for moving sessions between machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ txcript continue <file|->[#range]        # continue a Simple document instead:
     --with <harness> [...]                #   a file, or stdin (`-`), from any agent
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue` writes the session where the target harness keeps its sessions, then launches that harness on it, handing over the terminal:
@@ -155,6 +158,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10`: start through message 10
 
 `continue` accepts the same suffix and continues just those messages as a new session. A range that would cut a tool call away from its result is refused, and the error suggests the nearest valid range.
+
+`export` writes the session as a [Simple](docs/formats/simple.md) document, to stdout or `--out <file>`. The document is the full rendering of the canonical model — everything `continue` carries between harnesses — detached from any harness's store, so it moves between machines as a file:
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+The recorded working directory is kept when it exists on the importing machine and otherwise replaced by the directory `continue` runs in. `export` accepts the same `#range` suffix and `--from` scope as `view`.
 
 ### Search
 

--- a/cli/src/export.rs
+++ b/cli/src/export.rs
@@ -1,0 +1,181 @@
+//! `txcript export` — write a session as a Simple interchange document.
+//!
+//! The source is resolved exactly like `view` (id or exact title, optional
+//! `#range`). The output is the full-fidelity Simple rendering of the
+//! canonical model — every `Transcript<Common>` field has a slot in Simple —
+//! so the document is the session as txcript sees it, detached from any
+//! harness's store. `txcript continue <file> --with <harness>` brings it
+//! back into a harness, on this machine or another.
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use txcript::harness::simple::Simple;
+use txcript::{Codec, Common, HarnessId, TextCodec, Transcript};
+
+use crate::{fragment, view};
+
+pub fn cmd_export(
+    source: &str,
+    from: Option<HarnessId>,
+    out: Option<&Path>,
+) -> Result<ExitCode, String> {
+    let (common, request) = view::load_source(source, from)?;
+    let common = match &request {
+        Some(req) => fragment::sliced(&common, req)?,
+        None => common,
+    };
+    let text = render(&common)?;
+    match out {
+        Some(path) => {
+            std::fs::write(path, text).map_err(|e| format!("writing {}: {e}", path.display()))?;
+        }
+        // A failed write means the reader is gone (`txcript export … | head`):
+        // finish quietly instead of panicking the way `print!` would.
+        None => {
+            let _ = std::io::Write::write_all(&mut std::io::stdout(), text.as_bytes());
+        }
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+/// The Simple document for `common`: the canonical model rendered through
+/// the Simple codec, which keeps every field.
+pub fn render(common: &Transcript<Common>) -> Result<String, String> {
+    let native = Simple::from_common(common).map_err(|e| e.to_string())?;
+    Simple::to_text(&native).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use txcript::common::{
+        Artifact, ArtifactSource, Block, ImageSource, Message, Meta, Role, StopReason, Tool,
+        ToolOutput, Usage,
+    };
+    use txcript::harness::simple::Simple;
+    use txcript::{Codec, TextCodec, Transcript};
+
+    /// A transcript with every canonical field populated.
+    #[allow(clippy::too_many_lines)]
+    fn full() -> Transcript<txcript::Common> {
+        let t0 = Utc.with_ymd_and_hms(2026, 8, 21, 9, 30, 0).unwrap();
+        let meta = Meta {
+            id: "sess-1".into(),
+            timestamp: t0,
+            cwd: Some("/work/repo".into()),
+            git_branch: Some("main".into()),
+            title: Some("Export round trip".into()),
+            cli_version: Some("1.2.3".into()),
+            model: Some("claude-fable-5".into()),
+        };
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: vec![
+                    Block::Text {
+                        text: "run the tests".into(),
+                    },
+                    Block::Image {
+                        source: ImageSource {
+                            source_type: "base64".into(),
+                            media_type: "image/png".into(),
+                            data: "aGk=".into(),
+                        },
+                    },
+                ],
+                timestamp: t0,
+                model: None,
+                stop_reason: None,
+                usage: None,
+            },
+            Message {
+                role: Role::Assistant,
+                content: vec![
+                    Block::Thinking {
+                        text: "cargo test covers it".into(),
+                        signature: Some("sig".into()),
+                        encrypted: Some("enc".into()),
+                    },
+                    Block::ToolUse {
+                        id: "tu-1".into(),
+                        tool: Tool::Bash {
+                            command: "cargo test".into(),
+                            workdir: Some("/work/repo".into()),
+                            timeout_ms: Some(1000),
+                            description: Some("tests".into()),
+                            run_in_background: true,
+                        },
+                    },
+                    Block::ToolUse {
+                        id: "tu-2".into(),
+                        tool: Tool::Raw {
+                            tool_name: "mcp__x__y".into(),
+                            input: serde_json::json!({"k": [1, 2]}),
+                        },
+                    },
+                ],
+                timestamp: t0,
+                model: Some("claude-fable-5".into()),
+                stop_reason: Some(StopReason::ToolUse),
+                usage: Some(Usage {
+                    input_tokens: 10,
+                    output_tokens: 20,
+                    cache_read_input_tokens: Some(5),
+                    cache_creation_input_tokens: None,
+                }),
+            },
+            Message {
+                role: Role::User,
+                content: vec![
+                    Block::ToolResult {
+                        tool_use_id: "tu-1".into(),
+                        content: ToolOutput::Text("42 passed".into()),
+                        is_error: false,
+                    },
+                    Block::ToolResult {
+                        tool_use_id: "tu-2".into(),
+                        content: ToolOutput::Json(serde_json::json!({"ok": false})),
+                        is_error: true,
+                    },
+                ],
+                timestamp: t0,
+                model: None,
+                stop_reason: None,
+                usage: None,
+            },
+            Message {
+                role: Role::Assistant,
+                content: vec![
+                    Block::Text {
+                        text: "All green.".into(),
+                    },
+                    Block::Artifact {
+                        artifact: Artifact {
+                            id: "art-1".into(),
+                            name: "report.md".into(),
+                            source: ArtifactSource::Text {
+                                text: "# done".into(),
+                                media_type: Some("text/markdown".into()),
+                            },
+                        },
+                    },
+                ],
+                timestamp: t0,
+                model: None,
+                stop_reason: Some(StopReason::Other("custom".into())),
+                usage: None,
+            },
+        ];
+        Transcript::new(meta, messages)
+    }
+
+    #[test]
+    fn export_round_trips_every_canonical_field() {
+        let original = full();
+        let text = super::render(&original).unwrap();
+        let parsed = Simple::from_text(&text).unwrap();
+        let back = Simple::to_common(&parsed).unwrap();
+        assert_eq!(back, original);
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -49,6 +49,7 @@ use txcript::harness::{amp, simple};
 use txcript::{Codec, Common, HarnessId, TextCodec, Transcript, local};
 
 pub mod cache;
+mod export;
 pub mod fragment;
 #[cfg(feature = "mcp")]
 pub mod mcp;
@@ -96,7 +97,7 @@ pub enum Command {
     },
 }
 
-/// The session commands — `list`, `continue`, `view`, `query` — as one clap
+/// The session commands — `list`, `continue`, `view`, `export`, `query` — as one clap
 /// [`Subcommand`]. Usable on its own, or flattened into a larger command
 /// enum with `#[command(flatten)]` and dispatched through [`run_session`].
 #[derive(Subcommand)]
@@ -176,6 +177,25 @@ pub enum SessionCommand {
         /// Only look for the session in this harness
         #[arg(long, value_name = "HARNESS", value_parser = HarnessParser)]
         from: Option<HarnessId>,
+    },
+    /// Write a session as a Simple interchange document
+    ///
+    /// The document is the full-fidelity Simple rendering of the canonical
+    /// model (docs/formats/simple.md), detached from any harness's store.
+    /// Move it to another machine and `continue <file> --with <harness>`
+    /// picks the session up there; a `#range` exports just those messages.
+    Export {
+        /// Session id (any unambiguous prefix) or its exact title, with an
+        /// optional `#range` of 1-based inclusive message numbers
+        /// (`abc#5-12`, `#7`, `#5-`, `#-10`)
+        #[arg(value_hint = clap::ValueHint::Other)]
+        source: String,
+        /// Only look for the session in this harness
+        #[arg(long, value_name = "HARNESS", value_parser = HarnessParser)]
+        from: Option<HarnessId>,
+        /// Write the document to this file instead of stdout
+        #[arg(long, value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
+        out: Option<PathBuf>,
     },
     /// Search session content; without a pattern, open an fzf-style picker
     ///
@@ -316,6 +336,9 @@ pub fn run_session(command: SessionCommand, options: &Options) -> Result<ExitCod
             no_resume,
         } => cmd_continue(&id, with, from, out.as_ref(), no_resume),
         SessionCommand::View { source, from } => view::cmd_view(&source, from),
+        SessionCommand::Export { source, from, out } => {
+            export::cmd_export(&source, from, out.as_deref())
+        }
         SessionCommand::Query {
             pattern,
             with,

--- a/cli/src/view.rs
+++ b/cli/src/view.rs
@@ -8,11 +8,17 @@
 
 use std::process::ExitCode;
 
-use txcript::{HarnessId, Span, text};
+use txcript::{Common, HarnessId, Span, Transcript, text};
 
 use crate::fragment;
 
-pub fn cmd_view(source: &str, from: Option<HarnessId>) -> Result<ExitCode, String> {
+/// Resolve a `view`/`export` source — a session id or exact title, with
+/// an optional `#range` — to the session's canonical transcript and the
+/// parsed range request, if any.
+pub fn load_source(
+    source: &str,
+    from: Option<HarnessId>,
+) -> Result<(Transcript<Common>, Option<fragment::SpanReq>), String> {
     let sessions = super::discover_with_spinner(from)?;
     // A whole-input match (a title that itself contains `#12`) beats the
     // fragment interpretation.
@@ -35,6 +41,11 @@ pub fn cmd_view(source: &str, from: Option<HarnessId>) -> Result<ExitCode, Strin
     let common = session
         .read()
         .map_err(|e| format!("reading session `{src}`: {e}"))?;
+    Ok((common, request))
+}
+
+pub fn cmd_view(source: &str, from: Option<HarnessId>) -> Result<ExitCode, String> {
+    let (common, request) = load_source(source, from)?;
 
     let total = common.body.len();
     let span = match &request {

--- a/docs/formats/simple.md
+++ b/docs/formats/simple.md
@@ -49,10 +49,14 @@ harness's own store, and launches that harness on it. From that moment the
 conversation lives in the target harness; the source document is never
 modified.
 
-Simple is an interchange *input*: sessions are continued from Simple
-documents, not written into them, so `--with simple` is refused. (The codec
-itself is symmetric — the library and WASM APIs can render Simple text —
-but txcript manages no location to write such a document to.)
+A session txcript already knows is handed out the same way: `txcript export
+<id>` writes it as a Simple document, to stdout or `--out <file>`. Copy the
+file to another machine and `continue` it there.
+
+Simple has no store: `--with simple` is refused because txcript manages no
+location to continue a session into. `export` is the way out — it renders
+the document through the same symmetric codec the library and WASM APIs
+expose, and leaves where it goes to you.
 
 ## The format, level by level
 

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -121,6 +121,9 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue` schreibt die Session dorthin, wo der Ziel-Harness seine Sessions aufbewahrt, und startet anschließend diesen Harness darauf, wobei das Terminal übergeben wird:
@@ -137,6 +140,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10`: Anfang bis Nachricht 10
 
 `continue` akzeptiert dasselbe Suffix und setzt nur diese Nachrichten als neue Session fort. Ein Bereich, der einen Tool-Aufruf von seinem Ergebnis trennen würde, wird abgelehnt, und die Fehlermeldung schlägt den nächstgelegenen gültigen Bereich vor.
+
+`export` schreibt die Session als [Simple](../formats/simple.md)-Dokument, nach stdout oder mit `--out <file>`. Das Dokument ist die vollständige Darstellung des kanonischen Modells — alles, was `continue` zwischen Harnesses mitführt — unabhängig davon, wo ein Harness seine Sessions aufbewahrt, sodass es sich als Datei von einer Maschine zur anderen bewegen lässt:
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+Das aufgezeichnete Arbeitsverzeichnis wird beibehalten, wenn es auf der importierenden Maschine existiert, und andernfalls durch das Verzeichnis ersetzt, in dem `continue` läuft. `export` akzeptiert dasselbe `#range`-Suffix und denselben `--from`-Scope wie `view`.
 
 ### Suche
 

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -121,6 +121,9 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue` escribe la sesión donde el harness de destino guarda sus sesiones, y luego lo lanza sobre ella, cediéndole la terminal:
@@ -137,6 +140,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10`: desde el inicio hasta el mensaje 10
 
 `continue` acepta el mismo sufijo y continúa solo esos mensajes como una sesión nueva. Un rango que separaría una llamada a herramienta de su resultado se rechaza, y el error sugiere el rango válido más cercano.
+
+`export` escribe la sesión como un documento [Simple](../formats/simple.md), a stdout o a `--out <file>`. El documento es el renderizado completo del modelo canónico — todo lo que `continue` transporta entre harnesses — independiente de dónde guarda sus sesiones cada harness, así que se mueve de una máquina a otra como un archivo:
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+El directorio de trabajo registrado se conserva cuando existe en la máquina de importación, y en caso contrario se reemplaza por el directorio en el que se ejecuta `continue`. `export` acepta el mismo sufijo `#range` y el mismo alcance `--from` que `view`.
 
 ### Búsqueda
 

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -121,6 +121,9 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue` écrit la session là où le harnais cible conserve ses sessions, puis lance ce harnais dessus, en lui cédant le terminal :
@@ -137,6 +140,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10` : du début jusqu'au message 10
 
 `continue` accepte le même suffixe et ne poursuit que ces messages en tant que nouvelle session. Une plage qui séparerait un appel d'outil de son résultat est refusée, et l'erreur suggère la plage valide la plus proche.
+
+`export` écrit la session comme document [Simple](../formats/simple.md), sur stdout ou dans `--out <file>`. Le document est le rendu complet du modèle canonique — tout ce que `continue` transporte entre les harnais — indépendant de l'endroit où un harnais conserve ses sessions, si bien qu'il se déplace d'une machine à l'autre comme un fichier :
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+Le répertoire de travail enregistré est conservé lorsqu'il existe sur la machine d'importation, et sinon remplacé par le répertoire dans lequel `continue` s'exécute. `export` accepte le même suffixe `#range` et la même portée `--from` que `view`.
 
 ### Recherche
 

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -121,6 +121,9 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue` scrive la sessione dove l'harness di destinazione conserva le proprie sessioni, poi lo lancia su di essa, cedendogli il terminale:
@@ -137,6 +140,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10`: dall'inizio al messaggio 10
 
 `continue` accetta lo stesso suffisso e continua solo quei messaggi come nuova sessione. Un intervallo che separerebbe una chiamata a uno strumento dal suo risultato viene rifiutato, e l'errore suggerisce l'intervallo valido più vicino.
+
+`export` scrive la sessione come documento [Simple](../formats/simple.md), su stdout o in `--out <file>`. Il documento è il rendering completo del modello canonico — tutto ciò che `continue` porta con sé tra harness — indipendente da dove un harness conserva le proprie sessioni, così si sposta da una macchina all'altra come file:
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+La working directory registrata viene mantenuta quando esiste sulla macchina di importazione, altrimenti viene sostituita dalla directory in cui `continue` viene eseguito. `export` accetta lo stesso suffisso `#range` e lo stesso ambito `--from` di `view`.
 
 ### Ricerca
 

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -121,6 +121,9 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue` はセッションをターゲットハーネスがセッションを保存している場所に書き出し、続けてそのハーネスを起動してターミナルを引き渡します:
@@ -137,6 +140,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10`: 先頭からメッセージ 10 まで
 
 `continue` も同じサフィックスを受け付け、その範囲のメッセージだけを新しいセッションとして続行します。ツール呼び出しをその結果から切り離してしまう範囲は拒否され、エラーには最も近い有効な範囲が提案されます。
+
+`export` はセッションを [Simple](../formats/simple.md) ドキュメントとして、stdout または `--out <file>` に書き出します。このドキュメントは正準モデルの完全なレンダリング — `continue` がハーネス間で運ぶものすべて — であり、どのハーネスの保存場所からも切り離されているため、1 つのファイルとしてマシン間を移動できます:
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+記録された作業ディレクトリは、インポート先のマシンに存在すればそれを保持し、存在しなければ `continue` の実行ディレクトリに置き換えられます。`export` は `view` と同じ `#range` サフィックスと `--from` スコープを受け付けます。
 
 ### 検索
 

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -121,6 +121,9 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue`는 대상 하네스가 세션을 보관하는 위치에 세션을 기록한 다음, 그 하네스를 실행하며 터미널을 넘깁니다:
@@ -137,6 +140,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10`: 처음부터 메시지 10까지
 
 `continue`도 같은 접미사를 받아 해당 메시지들만 새 세션으로 이어갑니다. 도구 호출을 그 결과와 갈라놓는 범위는 거부되며, 오류 메시지가 가장 가까운 유효한 범위를 제안합니다.
+
+`export`는 세션을 [Simple](../formats/simple.md) 문서로, stdout 또는 `--out <file>`에 기록합니다. 이 문서는 정준 모델의 완전한 렌더링 — `continue`가 하네스 사이에서 옮기는 모든 것 — 이며, 어떤 하네스가 세션을 보관하는 위치와도 분리되어 있어 파일 하나로 이 머신에서 저 머신으로 옮길 수 있습니다:
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+기록된 작업 디렉터리는 가져오는 머신에 존재하면 그대로 유지되고, 그렇지 않으면 `continue`가 실행되는 디렉터리로 대체됩니다. `export`는 `view`와 같은 `#range` 접미사와 `--from` 범위를 받습니다.
 
 ### 검색
 

--- a/docs/translations/README.mr.md
+++ b/docs/translations/README.mr.md
@@ -121,6 +121,9 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue` टार्गेट हार्नेस जिथे सेशन्स ठेवतो तिथे सेशन लिहिते, आणि मग त्या सेशनवर तो हार्नेस लाँच करून टर्मिनल त्याच्या हवाली करते:
@@ -137,6 +140,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10`: सुरुवातीपासून मेसेज 10 पर्यंत
 
 `continue` ला हाच suffix चालतो, आणि तेवढेच मेसेज नवीन सेशन म्हणून पुढे चालू होतात. टूल कॉलला त्याच्या रिझल्टपासून तोडणारी रेंज नाकारली जाते, आणि एररमध्ये सर्वात जवळची वैध रेंज सुचवली जाते.
+
+`export` सेशनला [Simple](../formats/simple.md) डॉक्युमेंट म्हणून, stdout वर किंवा `--out <file>` मध्ये लिहिते. हा डॉक्युमेंट canonical मॉडेलचं पूर्ण रेंडरिंग आहे — `continue` हार्नेसेसमध्ये जे काही घेऊन जातो ते सगळं — आणि कोणताही हार्नेस त्याची सेशन्स जिथे ठेवतो तिथून तो वेगळा असतो, त्यामुळे तो एका मशीनवरून दुसऱ्या मशीनवर एक फाइल म्हणून नेता येतो:
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+इम्पोर्ट करणाऱ्या मशीनवर रेकॉर्ड केलेली working directory अस्तित्वात असेल तर ती तशीच ठेवली जाते, नाहीतर `continue` ज्या डिरेक्टरीत चालते तिने बदलली जाते. `export` ला `view` सारखाच `#range` suffix आणि `--from` scope चालतो.
 
 ### शोध
 

--- a/docs/translations/README.pt-BR.md
+++ b/docs/translations/README.pt-BR.md
@@ -121,6 +121,9 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue` grava a sessão onde o harness de destino mantém suas sessões, depois inicia esse harness nela, entregando o terminal:
@@ -137,6 +140,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10`: do início até a mensagem 10
 
 `continue` aceita o mesmo sufixo e continua apenas essas mensagens como uma nova sessão. Um intervalo que separaria uma chamada de ferramenta do seu resultado é recusado, e o erro sugere o intervalo válido mais próximo.
+
+`export` grava a sessão como documento [Simple](../formats/simple.md), em stdout ou em `--out <file>`. O documento é a renderização completa do modelo canônico — tudo que `continue` carrega entre harnesses — independente de onde um harness mantém suas sessões, então ele se move de uma máquina para outra como um arquivo:
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+O diretório de trabalho registrado é mantido quando existe na máquina de importação e, caso contrário, substituído pelo diretório em que `continue` é executado. `export` aceita o mesmo sufixo `#range` e o mesmo escopo `--from` que `view`.
 
 ### Pesquisa
 

--- a/docs/translations/README.ru.md
+++ b/docs/translations/README.ru.md
@@ -121,6 +121,9 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue` записывает сессию туда, где целевой харнесс хранит свои сессии, а затем запускает этот харнесс на ней, передавая ему терминал:
@@ -137,6 +140,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10`: с начала по сообщение 10
 
 `continue` принимает тот же суффикс и продолжает только эти сообщения как новую сессию. Диапазон, отрезающий вызов инструмента от его результата, отклоняется, а в ошибке предлагается ближайший допустимый диапазон.
+
+`export` записывает сессию как документ [Simple](../formats/simple.md) в stdout или в `--out <file>`. Документ — это полное представление канонической модели — всё, что `continue` переносит между харнессами — отделённое от хранилища любого харнесса, поэтому он перемещается с одной машины на другую как файл:
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+Записанный рабочий каталог сохраняется, если он существует на импортирующей машине, а иначе заменяется каталогом, в котором запускается `continue`. `export` принимает тот же суффикс `#range` и ту же область `--from`, что и `view`.
 
 ### Поиск
 

--- a/docs/translations/README.ta.md
+++ b/docs/translations/README.ta.md
@@ -121,6 +121,9 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue` டார்கெட் ஹார்னெஸ் தன் செஷன்களை வைக்கும் இடத்திலேயே செஷனை எழுதி, பிறகு அதன் மீது அந்த ஹார்னெஸை launch செய்து டெர்மினலை ஒப்படைக்கிறது:
@@ -137,6 +140,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10`: தொடக்கம் முதல் மெசேஜ் 10 வரை
 
 `continue`-க்கும் இதே suffix பொருந்தும்; அந்த மெசேஜ்கள் மட்டும் புதிய செஷனாகத் தொடரும். ஒரு டூல் காலை அதன் ரிசல்ட்டிலிருந்து பிரிக்கும் range நிராகரிக்கப்படும்; error-இல் அருகிலுள்ள செல்லுபடியான range பரிந்துரைக்கப்படும்.
+
+`export` செஷனை [Simple](../formats/simple.md) document ஆக, stdout-இல் அல்லது `--out <file>`-இல் எழுதுகிறது. இந்த document, canonical மாடலின் முழு rendering — `continue` ஒரு ஹார்னெஸிலிருந்து இன்னொரு ஹார்னெஸுக்கு கொண்டு போகும் எல்லாமே — ஆகும்; இது எந்த ஹார்னெஸும் தன் செஷன்களை வைக்கும் இடத்திலிருந்தும் தனியாக இருக்கும், அதனால் இது ஒரு மெஷினிலிருந்து இன்னொரு மெஷினுக்கு ஒரு file ஆக நகரும்:
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+இம்போர்ட் செய்யும் மெஷினில் பதிவு செய்யப்பட்ட working directory இருந்தால் அது அப்படியே வைக்கப்படும்; இல்லையென்றால் `continue` ரன் ஆகும் directory-ஆல் மாற்றப்படும். `export`-க்கும் `view` போலவே அதே `#range` suffix-உம் `--from` scope-உம் பொருந்தும்.
 
 ### தேடல்
 

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -121,6 +121,9 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue` 会把会话写到目标 harness 保存会话的位置，然后启动该 harness 打开它，并把终端交给它：
@@ -137,6 +140,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10`：从开头到第 10 条消息
 
 `continue` 接受同样的后缀，只把这些消息作为新会话继续。会把工具调用与其结果拆开的范围会被拒绝，错误信息会给出最接近的有效范围建议。
+
+`export` 把会话写为 [Simple](../formats/simple.md) 文档，输出到 stdout 或 `--out <file>`。该文档是规范模型的完整呈现——`continue` 在 harness 之间携带的一切——脱离了任何 harness 保存会话的位置，因此可以作为一个文件从一台机器移动到另一台机器：
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+记录的工作目录，如果在导入机器上存在就会保留，否则会被 `continue` 运行所在的目录替换。`export` 接受与 `view` 相同的 `#range` 后缀和 `--from` 范围。
 
 ### 搜索
 

--- a/docs/translations/README.zh-TW.md
+++ b/docs/translations/README.zh-TW.md
@@ -121,6 +121,9 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript view <id>[#range]                # print a session as compact text
     [--from <harness>]                    #   scope the id lookup to one harness
+txcript export <id>[#range]              # write a session as a Simple document
+    [--from <harness>]                    #   scope the id lookup to one harness
+    [--out <file>]                        #   write to <file> instead of stdout
 ```
 
 `continue` 會把工作階段寫到目標 harness 存放工作階段的位置，然後啟動該 harness 並把終端機交給它：
@@ -137,6 +140,15 @@ txcript view <id>[#range]                # print a session as compact text
 - `abc#-10`：從開頭到第 10 則
 
 `continue` 接受同樣的後綴，只把這些訊息作為新的工作階段接續。會把工具呼叫與其結果拆開的範圍會被拒絕，錯誤訊息會建議最接近的有效範圍。
+
+`export` 會把工作階段寫為 [Simple](../formats/simple.md) 文件，輸出到 stdout 或 `--out <file>`。此文件是標準模型的完整呈現——`continue` 在 harness 之間攜帶的一切——脫離了任何 harness 存放工作階段的位置，因此可以作為一個檔案從一台機器移到另一台機器：
+
+```sh
+txcript export 0dc114bf --out session.json       # on this machine
+txcript continue ./session.json --with claude_code   # on the other one
+```
+
+已記錄的工作目錄，如果在匯入端的機器上存在就會保留，否則會被 `continue` 執行所在的目錄取代。`export` 接受與 `view` 相同的 `#range` 後綴與 `--from` 範圍。
 
 ### 搜尋
 


### PR DESCRIPTION
## Summary

- `txcript export <id>[#range] [--from <harness>] [--out <file>]` writes a session as a Simple interchange document, to stdout by default.
- The document is the full-fidelity Simple rendering of `Transcript<Common>` — every canonical field (meta, per-message model/stop_reason/usage, thinking signatures, images, artifacts, typed and raw tools) — so it carries everything `continue` does between harnesses. As Common grows, the export grows with it.
- Import is the existing `txcript continue <file> --with <harness>`; no new verb. A recorded cwd that doesn't exist on the importing machine already rehomes to the current directory.
- `view` and `export` share source resolution (`view::load_source`).
- Docs: README CLI block and cross-machine recipe, `docs/formats/simple.md`, and all 12 translated READMEs.

## Verification

- Unit test: a transcript with every Common field populated round-trips `render → Simple::from_text → to_common` unchanged.
- End-to-end on a real 64-message Claude Code session (15 signed thinking blocks): `export` → `continue <file> --with {codex, claude_code, pi} --out` is byte-identical to `continue <id> --with … --out`; same via stdin (`export … | continue -`). `#1-5` exports 5 messages; `#1-4` is refused by the existing tool-pairing guard.
- `cargo test --workspace`, clippy, and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
