### PR TITLE
perf: make Cursor Desktop discovery and loads proportional to the session

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Discovery, listing, search, and `view` work for every harness with a backing sto
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [spec](docs/formats/pi.md) |
 | [Campfire](docs/formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [spec](docs/formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [spec](docs/formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [spec](docs/formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | JSON session dir | ⇄ | ✓ | [spec](docs/formats/grok.md) |
 | [fx](https://fx.sh) | `fx` | `~/.fx/sessions/` | event-log session dir | ⇄ | ✓ | [spec](docs/formats/fx.md) |
 | Hermes Agent | `hermes` | `~/.hermes/state.db` | SQLite | → | — <sup>3</sup> | [spec](docs/formats/hermes.md) |

--- a/docs/formats/README.md
+++ b/docs/formats/README.md
@@ -46,6 +46,7 @@ than none.
 | [codex.md](codex.md) | Codex CLI (OpenAI) | `src/harness/codex.rs` |
 | [opencode.md](opencode.md) | OpenCode (SST) | `src/harness/opencode.rs` |
 | [cursor.md](cursor.md) | Cursor | `src/harness/cursor.rs` |
+| [cursor-desktop.md](cursor-desktop.md) | Cursor desktop (IDE app) | `src/harness/cursor_desktop.rs` |
 | [amp.md](amp.md) | Amp (Sourcegraph) | `src/harness/amp.rs` |
 | [grok.md](grok.md) | Grok CLI (xAI) | `src/harness/grok.rs` |
 | [fx.md](fx.md) | fx (Vercel) | `src/harness/fx.rs` |

--- a/docs/formats/cursor-desktop.md
+++ b/docs/formats/cursor-desktop.md
@@ -1,0 +1,204 @@
+# Cursor desktop
+
+Cursor is Anysphere's AI coding product. txcript reads the agent sessions of
+its **desktop app** (the IDE's Agent panel and Agents home), which the app
+keeps as rows in one global SQLite database, `state.vscdb`. This is *not* the
+CLI agent's store — `cursor-agent` sessions live under `~/.cursor/chats` and
+are covered by [cursor.md](cursor.md). The format is closed source and
+undocumented: Cursor's docs describe chat history features but never the
+storage, and community forum threads confirm only the file path. Everything
+below is **reverse-engineered** from real local sessions and encoded in
+txcript's parser. Observations are from Cursor 3.16 and 3.17.8 on macOS.
+
+Each session (Cursor calls it a *composer*) is one row in a header table plus
+a handful of keys in a key-value table: a state document and one JSON
+"bubble" per message.
+
+```
+<Cursor User dir>/                       ~/Library/Application Support/Cursor/User
+├── globalStorage/
+│   └── state.vscdb                      SQLite, rollback journal
+│       ├── composerHeaders              one row per session: the discovery index
+│       │     composerId | workspaceId | createdAt | lastUpdatedAt | isArchived
+│       │     | isSubagent | recency | checkpointAt | value ({"type":"head",…})
+│       ├── cursorDiskKV (key, value)    the session bodies
+│       │     composerData:<cid>              state document (model, bubble order, …)
+│       │     bubbleId:<cid>:<bubbleId>       one message; type 1 user, 2 assistant
+│       │     checkpointId:<cid>:<id>         file checkpoints (carried, not read)
+│       │     composerVirtualRowHeights:<cid> renderer cache (carried, not read)
+│       │     agentKv:blob:<sha>              model-side request cache (not carried)
+│       └── ItemTable (key, value)       app state; the Agents sidebar index lives here
+│             glass.localAgentProjects.v1
+│             glass.localAgentProjectMembership.v1
+└── workspaceStorage/<hash>/workspace.json   {"folder": "file:///…"} → workspaceId
+```
+
+## On disk
+
+The root is the app's `User` directory: `~/Library/Application Support/Cursor/User`
+on macOS, `%USERPROFILE%\AppData\Roaming\Cursor\User` on Windows,
+`~/.config/Cursor/User` elsewhere (`CursorDesktopStore::default_root()`). The
+`CURSOR_DESKTOP_USER_DIR` environment variable overrides it. Every session on
+the machine lives in the single database at `globalStorage/state.vscdb`;
+`-wal`/`-shm` sidecars sit beside it while the app is running, and txcript
+opens it read-only. Workspace ids in `composerHeaders.workspaceId` are the
+app's own 32-hex-digit hashes (or `empty-window` for a session with no
+folder); `workspaceStorage/<hash>/workspace.json` maps a hash back to its
+folder URI.
+
+Discovery is one query over `composerHeaders`, newest `recency` first, joined
+to each session's `composerData:` cell and filtered to sessions that own at
+least one `bubbleId:` row — drafts and empty composers (the app keeps an
+`empty-state-draft` row, for instance) are not sessions. Bubble bodies are
+never read during discovery. Databases from before Cursor introduced the
+header table (the app records the migration under the
+`composer.composerHeaders.migratedToTable` key) fall back to scanning
+`composerData:` keys and synthesizing a head from each document. The session
+id txcript reports is the `composerId`, a UUID. Change detection uses
+`composerHeaders.lastUpdatedAt`.
+
+SQLite support is gated behind the `opencode` cargo feature (the shared
+rusqlite dependency); without it the store is inert, though the codec still
+converts txcript's JSON text form.
+
+## Dissection of a transcript
+
+A session's native body is its header row and every `cursorDiskKV` row keyed
+by its composer id, each cell kept as the raw text the app wrote. Messages are
+the `bubbleId:` rows, read in the order `composerData.fullConversationHeadersOnly`
+lists them (by `rowid` when that list is absent). Nothing threads bubbles to
+each other; the state document's list is the only ordering.
+
+| Their name | What it is | Maps to |
+| --- | --- | --- |
+| `composerHeaders.composerId` | The session id (UUID) | `Meta.id` |
+| `composerHeaders.createdAt` | ms epoch | `Meta.timestamp` |
+| `composerHeaders.value` (`{"type":"head",…}`) | `name`, `workspaceIdentifier.uri.fsPath`, `trackedGitRepos`, `unifiedMode`, `isDraft`, `isArchived` | `Meta.title` (`name`, else `subtitle`); `Meta.cwd` (`workspaceIdentifier.uri.fsPath`, else `agentLocation.environment.uri.fsPath`, else `trackedGitRepos[0].repoPath`) |
+| `composerData:<cid>` (`_v` 17) | The composer's full state document: `modelConfig`, `fullConversationHeadersOnly`, context, todos, flags | `Meta.model` from `modelConfig.modelName` (`"default"` is the picker placeholder, not a model); bubble order from `fullConversationHeadersOnly[].bubbleId` |
+| `bubbleId:<cid>:<bubbleId>` (`_v` 3) | One message document; `type` 1 user, 2 assistant; `createdAt` RFC 3339 | one `Message`, or part of one |
+| user bubble `text` (with `richText`, `context`) | The prompt as plain text; `richText` is the same text as a ProseMirror document; `context` lists attachments | `Role::User` with one `Block::Text` |
+| assistant bubble `text` | A visible response segment | `Block::Text` |
+| `thinking` `{text, signature}` (`capabilityType` 30) | A reasoning segment and its provider signature | `Block::Thinking` (skipped when `text` is blank) |
+| `toolFormerData` (`capabilityType` 15) | A tool call *and* its result: `tool` (numeric id), `name`, `toolCallId`, `params` (JSON as a string), `status`, `result` (string) | `Block::ToolUse` on the assistant message, then a `Role::User` message holding the `Block::ToolResult` |
+| `toolFormerData.status` | `started`, `completed`, `error` | `completed`/`error` pair a result (`is_error` on `error`); anything else is in flight and yields no result |
+| `toolFormerData.result` | The tool's output as a string | `ToolOutput::Json` when it parses as non-null JSON, else `ToolOutput::Text` |
+| `modelInfo.modelName` | Model per bubble | `Message.model` |
+| `tokenCount` `{inputTokens, outputTokens}` | Per-bubble counts; all-zero is the serializer default | `Message.usage` when either is non-zero |
+| `run_terminal_command_v2` (tool 15), `read_file_v2` (40) | Cursor's shell and read tools | `Tool::Bash` (`command`, `cwd`→`workdir`, `options.timeout`→`timeout_ms`), `Tool::Read` (`targetFile`→`file_path`, `offset`, `limit`) |
+| `ripgrep_raw_search` (41), `glob_file_search` (42), `ask_question` (51), MCP tools, … | The rest of Cursor's tool vocabulary | `Tool::Raw`, name and params untouched |
+| `checkpointId:<cid>…`, `composerVirtualRowHeights:<cid>`, any other `<kind>:<cid>…` key | File checkpoints, renderer caches, future record kinds | carried verbatim in the native body; no `Message` |
+| `agentKv:blob:*` | Content-addressed model-side request cache, commingled across sessions | not carried; the app regenerates it |
+
+Consecutive assistant bubbles fold into one assistant `Message`: a thinking
+bubble, a text bubble, and a tool bubble in a row become one message with
+three blocks. A tool call closes the assistant message, because the paired
+result must follow as its own user message. User bubbles with blank text are
+dropped, as are bubbles that fail to parse as JSON (they still survive
+natively). Cursor call ids can contain characters other harnesses reject (a
+literal newline has been observed), so ids are folded onto `[A-Za-z0-9_-]`;
+a missing id gets a deterministic UUIDv5 from the session id and position.
+`Meta.git_branch`, `Meta.cli_version`, and `stop_reason` are never present.
+
+A real assistant tool bubble, with the empty-collection skeleton Cursor's
+serializer writes on every bubble stripped out:
+
+```json
+{
+  "_v": 3,
+  "type": 2,
+  "bubbleId": "9ec20cdb-efd4-5159-8af2-c3c3ad9cf80c",
+  "createdAt": "2026-08-17T18:55:41.627Z",
+  "modelInfo": {"modelName": "claude-fable-5"},
+  "tokenCount": {"inputTokens": 2, "outputTokens": 497},
+  "capabilityType": 15,
+  "toolFormerData": {
+    "tool": 15,
+    "name": "run_terminal_command_v2",
+    "toolCallId": "toolu_012XHqBKN3SbRtVsid4vorRj",
+    "params": "{\"command\":\"grep -rn download --include=*.tsx -il app\"}",
+    "rawArgs": "",
+    "status": "completed",
+    "result": "app/components/download-button.tsx\n"
+  }
+}
+```
+
+txcript's text form of a session is a JSON object with the header row's
+columns, the `composer_data` cell, and the `bubbles` and `aux` rows as
+`{key, value}` pairs, every cell still a string.
+
+### Writing
+
+Coming *from* Common, txcript synthesizes what the app's loader insists on:
+a complete `composerData` document (started from a default-state template
+captured from a fresh Cursor 3.16 composer — sparser documents fail with
+"Failed to load composer data"), the full bubble skeleton, a ProseMirror
+`richText` for each user turn, and a `fullConversationHeadersOnly` entry per
+bubble whose `grouping` flags (`isRenderable` above all) the renderer needs
+before it will open the conversation. Tool results are written back onto the
+call's bubble, whose `createdAt` becomes the result time. Known tools get
+their numeric ids back. An untitled session is named from its first user
+turn, because the Agents sidebar hides unnamed sessions.
+
+Writing a session is not enough for the app to list it. The Agents home
+sidebar reads `glass.localAgentProjects.v1` (projects keyed by workspace
+folder) and `glass.localAgentProjectMembership.v1` (composer id → project)
+from `ItemTable`; a session absent from the membership map never appears. On
+save txcript adds the session to the project for `Meta.cwd`, creating the
+project when needed, and resolves the header's `workspaceId` from
+`workspaceStorage/*/workspace.json`. Without a `cwd` the session is written
+but not registered. Saves replace the session's bubbles wholesale inside one
+transaction.
+
+## Caveats
+
+- **Reverse-engineered; expect drift.** Shapes are from Cursor 3.16 and
+  3.17.8 (`composerData._v` 17, bubble `_v` 3). The loader's requirements —
+  which fields of `composerData` and `grouping` it refuses to open without —
+  were found by deletion bisection, not from a spec. A release that changes
+  them breaks resume of imported sessions before it breaks reading.
+- **Thinking is often signature-only.** On recent Cursor builds the
+  `thinking.text` of an assistant bubble is empty and only the provider
+  `signature` is stored. Those bubbles produce no `Thinking` block, so a
+  session can look thought-free in Common while the app shows a thinking
+  duration.
+- **Only two tools are typed.** Shell and read calls become `Tool::Bash` and
+  `Tool::Read`; every other native tool — search, glob, ask, MCP — stays
+  `Tool::Raw`. Cursor's own edit tools have not been observed with a numeric
+  id in real sessions and are not renamed. Sessions txcript imported carry
+  canonical names (`Edit`, `Write`, `Bash`) with no `tool` number, and read
+  back as typed tools.
+- **Lossy through Common by design.** Image blocks, stop reasons, encrypted
+  thinking, `Tool::Bash` `description`/`run_in_background`, and the
+  distinction between a text result and a JSON-shaped text result (it comes
+  back as `ToolOutput::Json`) are lost. Native load keeps every cell
+  byte-for-byte, so a same-harness round trip is lossless.
+- **The `agentKv` cache is deliberately not carried.** Its blobs are shared
+  across sessions with no per-session root on disk. Cursor 3.16 lists,
+  renders, and continues a session with every `agentKv` blob deleted, so the
+  bubbles are the carrier.
+- **One database for everything.** Discovery, load, and save all touch the
+  same file the running app has open. Reads are read-only and safe;
+  `save` and `delete` write into a live app's database, and the app may not
+  notice until it reloads.
+- **Older per-workspace stores are not read.** Earlier Cursor versions kept
+  chat history in `workspaceStorage/<hash>/state.vscdb`; txcript reads only
+  the global database.
+- Hostile input: session ids are validated as path components before writes,
+  and `delete()` removes the header row plus every `cursorDiskKV` key naming
+  the id, failing if no header row existed.
+
+## References
+
+No public specification of `state.vscdb` exists. Cursor's chat history docs
+(<https://cursor.com/docs/agent/chat/history>, accessed 2026-09-01) describe
+the feature and not the storage. The community thread "Where are cursor chats
+stored?" (<https://forum.cursor.com/t/where-are-cursor-chats-stored/77295>,
+accessed 2026-09-01) confirms the global database path and nothing of its
+schema. This document is reverse-engineered.
+
+The authoritative mapping is `src/harness/cursor_desktop.rs`, exercised by
+`tests/integration/cursor_desktop.rs`.
+
+Last verified: 2026-09-01, against src/harness/cursor_desktop.rs and real local
+sessions from Cursor 3.17.8.

--- a/docs/formats/cursor.md
+++ b/docs/formats/cursor.md
@@ -3,12 +3,12 @@
 Cursor is Anysphere's AI coding product. txcript reads the sessions of its
 **CLI agent** (`cursor-agent`, resumed with `agent --resume=<id>`), which keeps
 a resumable chat store per session under `~/.cursor/chats`. This is *not* the
-editor's chat storage — IDE chats live elsewhere (`state.vscdb`) and are not
-read by txcript. The format is closed source and undocumented; everything in
-this page is reverse-engineered from real local sessions and encoded in
-txcript's parser. Cursor's SDK docs describe a matching *abstract* store
-(content-addressed "checkpoint" blobs, a `rootBlobId` pointer) but publish no
-schema, table names, or file paths.
+editor's chat storage — IDE chats live in the app's `state.vscdb` and are
+covered by [cursor-desktop.md](cursor-desktop.md). The format is closed source
+and undocumented; everything in this page is reverse-engineered from real
+local sessions and encoded in txcript's parser. Cursor's SDK docs describe a
+matching *abstract* store (content-addressed "checkpoint" blobs, a
+`rootBlobId` pointer) but publish no schema, table names, or file paths.
 
 ```
 ~/.cursor/chats/

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -80,7 +80,7 @@ Discovery, Auflistung, Suche, `view` und native Round-Trips funktionieren für j
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [Spec](../formats/pi.md) |
 | [Campfire](../formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [Spec](../formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [Spec](../formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [Spec](../formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | JSON-Session-Verzeichnis | ⇄ | ✓ | [Spec](../formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | Thread-JSON | → | — <sup>1</sup> | [Spec](../formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [Spec](../formats/antigravity.md) |

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -80,7 +80,7 @@ El descubrimiento, el listado, la búsqueda, `view` y las idas y vueltas nativas
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [spec](../formats/pi.md) |
 | [Campfire](../formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [spec](../formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [spec](../formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [spec](../formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | directorio de sesión (JSON) | ⇄ | ✓ | [spec](../formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | JSON del hilo | → | — <sup>1</sup> | [spec](../formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [spec](../formats/antigravity.md) |

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -80,7 +80,7 @@ La découverte, le listage, la recherche, `view` et les allers-retours natifs fo
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [spec](../formats/pi.md) |
 | [Campfire](../formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [spec](../formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [spec](../formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [spec](../formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | répertoire de session (JSON) | ⇄ | ✓ | [spec](../formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | JSON de thread | → | — <sup>1</sup> | [spec](../formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [spec](../formats/antigravity.md) |

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -80,7 +80,7 @@ Discovery, elenco, ricerca, `view` e round-trip nativi funzionano per ogni harne
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [spec](../formats/pi.md) |
 | [Campfire](../formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [spec](../formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [spec](../formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [spec](../formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | directory di sessione (JSON) | ⇄ | ✓ | [spec](../formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | JSON del thread | → | — <sup>1</sup> | [spec](../formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [spec](../formats/antigravity.md) |

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -80,7 +80,7 @@ flowchart LR
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [仕様](../formats/pi.md) |
 | [Campfire](../formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [仕様](../formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [仕様](../formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [仕様](../formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | セッションディレクトリ（JSON） | ⇄ | ✓ | [仕様](../formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | スレッド JSON | → | — <sup>1</sup> | [仕様](../formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [仕様](../formats/antigravity.md) |

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -80,7 +80,7 @@ flowchart LR
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [스펙](../formats/pi.md) |
 | [Campfire](../formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [스펙](../formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [스펙](../formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [스펙](../formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | 세션 디렉터리 JSON | ⇄ | ✓ | [스펙](../formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | 스레드 JSON | → | — <sup>1</sup> | [스펙](../formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [스펙](../formats/antigravity.md) |

--- a/docs/translations/README.mr.md
+++ b/docs/translations/README.mr.md
@@ -80,7 +80,7 @@ flowchart LR
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [स्पेक](../formats/pi.md) |
 | [Campfire](../formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [स्पेक](../formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [स्पेक](../formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [स्पेक](../formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | सेशन डिरेक्टरी (JSON) | ⇄ | ✓ | [स्पेक](../formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | थ्रेड JSON | → | — <sup>1</sup> | [स्पेक](../formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [स्पेक](../formats/antigravity.md) |

--- a/docs/translations/README.pt-BR.md
+++ b/docs/translations/README.pt-BR.md
@@ -80,7 +80,7 @@ Descoberta, listagem, pesquisa, `view` e round-trips nativos funcionam para todo
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [spec](../formats/pi.md) |
 | [Campfire](../formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [spec](../formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [spec](../formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [spec](../formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | diretório de sessão (JSON) | ⇄ | ✓ | [spec](../formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | JSON da thread | → | — <sup>1</sup> | [spec](../formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [spec](../formats/antigravity.md) |

--- a/docs/translations/README.ru.md
+++ b/docs/translations/README.ru.md
@@ -80,7 +80,7 @@ flowchart LR
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [спецификация](../formats/pi.md) |
 | [Campfire](../formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [спецификация](../formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [спецификация](../formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [спецификация](../formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | каталог сессии (JSON) | ⇄ | ✓ | [спецификация](../formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | JSON треда | → | — <sup>1</sup> | [спецификация](../formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [спецификация](../formats/antigravity.md) |

--- a/docs/translations/README.ta.md
+++ b/docs/translations/README.ta.md
@@ -80,7 +80,7 @@ flowchart LR
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [ஸ்பெக்](../formats/pi.md) |
 | [Campfire](../formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [ஸ்பெக்](../formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [ஸ்பெக்](../formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [ஸ்பெக்](../formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | செஷன் டைரக்டரி (JSON) | ⇄ | ✓ | [ஸ்பெக்](../formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | த்ரெட் JSON | → | — <sup>1</sup> | [ஸ்பெக்](../formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [ஸ்பெக்](../formats/antigravity.md) |

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -80,7 +80,7 @@ flowchart LR
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [规格](../formats/pi.md) |
 | [Campfire](../formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [规格](../formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [规格](../formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [规格](../formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | 会话目录（JSON） | ⇄ | ✓ | [规格](../formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | 线程 JSON | → | — <sup>1</sup> | [规格](../formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [规格](../formats/antigravity.md) |

--- a/docs/translations/README.zh-TW.md
+++ b/docs/translations/README.zh-TW.md
@@ -80,7 +80,7 @@ flowchart LR
 | [pi](https://pi.dev) | `pi` | `~/.pi/agent/sessions/` | JSONL | ⇄ | ✓ | [規格](../formats/pi.md) |
 | [Campfire](../formats/campfire.md) | `campfire` | `~/.campfire/agent/sessions/` | JSONL | ⇄ | ✓ | [規格](../formats/campfire.md) |
 | [Cursor CLI](https://cursor.com/cli) | `cursor` | `~/.cursor/chats/` | SQLite | ⇄ | ✓ | [規格](../formats/cursor.md) |
-| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | — |
+| [Cursor desktop](https://cursor.com) | `cursor_desktop` | `<Cursor User dir>/globalStorage/` | SQLite | ⇄ | ✓ | [規格](../formats/cursor-desktop.md) |
 | [Grok CLI](https://github.com/xai-org/grok-build) | `grok` | `~/.grok/sessions/` | JSON 工作階段目錄 | ⇄ | ✓ | [規格](../formats/grok.md) |
 | [Amp](https://ampcode.com) | `amp` | `~/.local/share/amp/threads/` | 對話串 JSON | → | — <sup>1</sup> | [規格](../formats/amp.md) |
 | [Antigravity](https://antigravity.google) | `antigravity` | `~/.gemini/antigravity-cli/` | SQLite | ⇄ | ✓ | [規格](../formats/antigravity.md) |

--- a/src/harness/cursor_desktop.rs
+++ b/src/harness/cursor_desktop.rs
@@ -118,6 +118,7 @@ impl TextCodec for CursorDesktop {
 // -- meta ----------------------------------------------------------------
 
 /// The composer id recorded in the header document, if any.
+#[cfg(feature = "opencode")]
 fn header_composer_id(body: &DesktopSession) -> Option<String> {
     let header: Value = serde_json::from_str(&body.header).ok()?;
     header
@@ -128,11 +129,24 @@ fn header_composer_id(body: &DesktopSession) -> Option<String> {
 }
 
 fn meta_from_session(body: &DesktopSession, id: Option<&str>) -> Meta {
-    let header: Value = serde_json::from_str(&body.header).unwrap_or(Value::Null);
-    let composer_data = body
-        .composer_data
-        .as_deref()
-        .and_then(|s| serde_json::from_str::<Value>(s).ok());
+    meta_from_parts(
+        &body.header,
+        body.composer_data.as_deref(),
+        body.created_at,
+        id,
+    )
+}
+
+/// Session metadata from the head document and `composerData:` cell alone —
+/// everything discovery needs without touching the bubble rows.
+fn meta_from_parts(
+    header: &str,
+    composer_data: Option<&str>,
+    created_at: i64,
+    id: Option<&str>,
+) -> Meta {
+    let header: Value = serde_json::from_str(header).unwrap_or(Value::Null);
+    let composer_data = composer_data.and_then(|s| serde_json::from_str::<Value>(s).ok());
     let title = [header.get("name"), header.get("subtitle")]
         .into_iter()
         .flatten()
@@ -154,13 +168,19 @@ fn meta_from_session(body: &DesktopSession, id: Option<&str>) -> Meta {
         .and_then(Value::as_str)
         .filter(|m| !m.is_empty() && *m != "default")
         .map(str::to_string);
-    let timestamp = DateTime::from_timestamp_millis(body.created_at)
-        .filter(|_| body.created_at > 0)
+    let timestamp = DateTime::from_timestamp_millis(created_at)
+        .filter(|_| created_at > 0)
         .unwrap_or_else(Utc::now);
     Meta {
         id: id
             .map(str::to_string)
-            .or_else(|| header_composer_id(body))
+            .or_else(|| {
+                header
+                    .get("composerId")
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+            })
             .unwrap_or_default(),
         timestamp,
         cwd,
@@ -1059,6 +1079,10 @@ impl Store for CursorDesktopStore {
             return Ok(Vec::new());
         }
         let conn = open_ro(&db_path)?;
+        if has_table(&conn, "composerHeaders")? {
+            return discover_from_headers(&conn);
+        }
+        // Pre-table databases: walk composerData keys and read each session.
         Ok(list_headers(&conn)
             .unwrap_or_default()
             .into_iter()
@@ -1218,6 +1242,150 @@ fn list_headers(conn: &Connection) -> Result<Vec<String>> {
 }
 
 #[cfg(feature = "opencode")]
+fn has_table(conn: &Connection, name: &str) -> Result<bool> {
+    conn.query_row(
+        "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        params![name],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|n| n > 0)
+    .map_err(sqlite_err)
+}
+
+/// Discovery over `composerHeaders` alone: one pass over the header table,
+/// an indexed point lookup for each `composerData:` cell, and an indexed
+/// range probe for "has at least one bubble". Never reads bubble bodies and
+/// never scans the key-value table, so it stays flat as the store grows.
+#[cfg(feature = "opencode")]
+fn discover_from_headers(conn: &Connection) -> Result<Vec<Discovered<String>>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT h.composerId, h.value, h.createdAt,
+                    (SELECT CAST(value AS TEXT) FROM cursorDiskKV
+                      WHERE key = 'composerData:' || h.composerId)
+             FROM composerHeaders h
+             WHERE EXISTS (SELECT 1 FROM cursorDiskKV
+                            WHERE key >= 'bubbleId:' || h.composerId || ':'
+                              AND key <  'bubbleId:' || h.composerId || ';')
+             ORDER BY h.recency DESC",
+        )
+        .map_err(sqlite_err)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        })
+        .map_err(sqlite_err)?;
+    Ok(rows
+        .filter_map(std::result::Result::ok)
+        .map(|(cid, header, created, data)| Discovered {
+            meta: meta_from_parts(
+                header.as_deref().unwrap_or_default(),
+                data.as_deref(),
+                created.unwrap_or_default(),
+                Some(&cid),
+            ),
+            reference: cid,
+        })
+        .collect())
+}
+
+/// Half-open key range covering every key that starts with `prefix`: the
+/// upper bound is the prefix with its last character stepped up by one
+/// code point, which sorts after every extension of the prefix under
+/// the default byte-wise `BINARY` collation. A range probe walks the key index;
+/// the equivalent `LIKE 'prefix%'` cannot, because `LIKE` is
+/// case-insensitive by default, and scans the whole table instead.
+#[cfg(feature = "opencode")]
+fn prefix_range(prefix: &str) -> (String, String) {
+    let mut hi = prefix.to_string();
+    if let Some(next) = hi.pop().and_then(|c| char::from_u32(c as u32 + 1)) {
+        hi.push(next);
+    } else {
+        hi = prefix.to_string();
+        hi.push('\u{10FFFF}');
+    }
+    (prefix.to_string(), hi)
+}
+
+/// Every bubble row of one session.
+#[cfg(feature = "opencode")]
+fn bubble_range(cid: &str) -> (String, String) {
+    prefix_range(&format!("bubbleId:{cid}:"))
+}
+
+/// The distinct `<kind>:` key prefixes in the key-value table, found by
+/// skipping through the key index one prefix at a time: each step seeks to
+/// the smallest key past the previous prefix's range, so the cost is a
+/// handful of index seeks regardless of table size. Keys without a colon
+/// name no session and are stepped over individually.
+#[cfg(feature = "opencode")]
+fn key_kinds(conn: &Connection) -> Result<Vec<String>> {
+    let mut from = conn
+        .prepare("SELECT min(key) FROM cursorDiskKV WHERE key >= ?1")
+        .map_err(sqlite_err)?;
+    let mut after = conn
+        .prepare("SELECT min(key) FROM cursorDiskKV WHERE key > ?1")
+        .map_err(sqlite_err)?;
+    let mut kinds = Vec::new();
+    let mut next = from
+        .query_row(params![""], |r| r.get::<_, Option<String>>(0))
+        .map_err(sqlite_err)?;
+    while let Some(key) = next {
+        next = match key.find(':') {
+            Some(i) => {
+                let kind = key[..=i].to_string();
+                let (_, hi) = prefix_range(&kind);
+                kinds.push(kind);
+                from.query_row(params![hi], |r| r.get(0))
+            }
+            None => after.query_row(params![key], |r| r.get(0)),
+        }
+        .map_err(sqlite_err)?;
+    }
+    Ok(kinds)
+}
+
+/// Rows of unmodeled kinds keyed by the session — `checkpointId:<cid>…`,
+/// `composerVirtualRowHeights:<cid>`, and whatever the app adds next — in
+/// database order. One indexed range probe per kind, so a session's cost
+/// does not grow with the size of the store.
+#[cfg(feature = "opencode")]
+fn read_aux(conn: &Connection, cid: &str) -> Result<Vec<DesktopRow>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT rowid, key, CAST(value AS TEXT) FROM cursorDiskKV
+             WHERE key >= ?1 AND key < ?2",
+        )
+        .map_err(sqlite_err)?;
+    let mut rows: Vec<(i64, DesktopRow)> = Vec::new();
+    for kind in key_kinds(conn)? {
+        if matches!(kind.as_str(), "bubbleId:" | "composerData:" | "agentKv:") {
+            continue;
+        }
+        let (lo, hi) = prefix_range(&format!("{kind}{cid}"));
+        let found = stmt
+            .query_map(params![lo, hi], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    DesktopRow {
+                        key: row.get(1)?,
+                        value: row.get(2)?,
+                    },
+                ))
+            })
+            .map_err(sqlite_err)?;
+        rows.extend(found.filter_map(std::result::Result::ok));
+    }
+    rows.sort_by_key(|(rowid, _)| *rowid);
+    Ok(rows.into_iter().map(|(_, row)| row).collect())
+}
+
+#[cfg(feature = "opencode")]
 fn read_session(conn: &Connection, cid: &str) -> Result<DesktopSession> {
     let header_row = conn
         .query_row(
@@ -1272,22 +1440,14 @@ fn read_session(conn: &Connection, cid: &str) -> Result<DesktopSession> {
             )
         };
 
+    let (lo, hi) = bubble_range(cid);
     let bubbles = keyed_rows(
         conn,
         "SELECT key, CAST(value AS TEXT) FROM cursorDiskKV
-         WHERE key LIKE ?1 ORDER BY rowid",
-        &[&format!("bubbleId:{cid}:%")],
+         WHERE key >= ?1 AND key < ?2 ORDER BY rowid",
+        &[&lo, &hi],
     )?;
-    let aux = keyed_rows(
-        conn,
-        "SELECT key, CAST(value AS TEXT) FROM cursorDiskKV
-         WHERE key LIKE ?1
-           AND key NOT LIKE ?2
-           AND key NOT LIKE 'composerData:%'
-           AND key NOT LIKE 'agentKv:%'
-         ORDER BY rowid",
-        &[&format!("%{cid}%"), &format!("bubbleId:{cid}:%")],
-    )?;
+    let aux = read_aux(conn, cid)?;
 
     Ok(DesktopSession {
         header,


### PR DESCRIPTION
## Problem

`txcript list --from cursor_desktop` hangs on large Cursor stores. Every session ran two `LIKE` queries over `cursorDiskKV`; SQLite cannot use the key index for either (`LIKE` is case-insensitive by default, and one pattern leads with a wildcard), so each was a full index walk. Discovery also read and parsed every bubble body just to check for emptiness. Cost was sessions × rows: on a 7.9 GB store, thousands of full scans.

## Fix

- Discovery reads `composerHeaders` only, with an indexed lookup for `composerData:` and an indexed range probe for "has at least one bubble". No bubble bodies are read.
- Loads use half-open key ranges (`prefix_range`) instead of `LIKE`; every read query is now a `SEARCH` in `EXPLAIN QUERY PLAN`.
- The `%cid%` sweep for unmodeled row kinds is replaced by an index-skipping enumeration of distinct `<kind>:` prefixes plus one range probe per kind, so unknown kinds still round-trip.
- The pre-table fallback triggers only when `composerHeaders` is absent, not on any error.

## Verification

Synthetic store (2000 sessions, 142 MB) and the real local store, release build:

| | before | after |
|---|---|---|
| `list` | 101 s | 0.56 s |
| load every session | 57 s | 0.56 s |
| cold `query` | not measured | 0.96 s |

Discover-vs-load `Meta` parity and old-vs-new aux-row parity held on every session of both stores (unknown kinds included). `cargo test --workspace --all-features`, both clippy configurations, and `cargo fmt --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
