### PR TITLE
fix: preserve tool arguments, parallel tool results, and workspace IDs across harnesses

### DIFF
--- a/src/harness/cursor.rs
+++ b/src/harness/cursor.rs
@@ -1742,6 +1742,8 @@ fn denormalize_cursor_args(tool: &str, input: Value) -> Value {
                     let key = match (tool, k.as_str()) {
                         (_, "file_path") => "path",
                         ("Bash", "workdir") => "cwd",
+                        ("Edit", "old_string") => "oldString",
+                        ("Edit", "new_string") => "newString",
                         // Keys the formats agree on pass through unchanged.
                         _ => k.as_str(),
                     }

--- a/src/harness/cursor_desktop.rs
+++ b/src/harness/cursor_desktop.rs
@@ -476,6 +476,29 @@ fn normalize_tool(name: &str, params: Value) -> Tool {
             }
             Tool::from_canonical("Read", Value::Object(input))
         }
+        "write_file_v2" => {
+            let mut input = Map::new();
+            if let Some(path) = params.get("targetFile") {
+                input.insert("file_path".into(), path.clone());
+            }
+            if let Some(contents) = params.get("contents") {
+                input.insert("content".into(), contents.clone());
+            }
+            Tool::from_canonical("Write", Value::Object(input))
+        }
+        "edit_file_v2" => {
+            let mut input = Map::new();
+            if let Some(path) = params.get("targetFile") {
+                input.insert("file_path".into(), path.clone());
+            }
+            if let Some(old) = params.get("oldString") {
+                input.insert("old_string".into(), old.clone());
+            }
+            if let Some(new) = params.get("newString") {
+                input.insert("new_string".into(), new.clone());
+            }
+            Tool::from_canonical("Edit", Value::Object(input))
+        }
         _ => Tool::from_canonical(name, params),
     }
 }
@@ -519,6 +542,24 @@ fn denormalize_tool(tool: &Tool) -> (String, Value, Option<u64>) {
                 params.insert("limit".into(), Value::from(*l));
             }
             ("read_file_v2".into(), Value::Object(params), Some(40))
+        }
+        Tool::Write { file_path, content } => {
+            let mut params = Map::new();
+            params.insert("targetFile".into(), Value::from(file_path.clone()));
+            params.insert("contents".into(), Value::from(content.clone()));
+            ("write_file_v2".into(), Value::Object(params), Some(43))
+        }
+        Tool::Edit {
+            file_path,
+            old_string,
+            new_string,
+            ..
+        } => {
+            let mut params = Map::new();
+            params.insert("targetFile".into(), Value::from(file_path.clone()));
+            params.insert("oldString".into(), Value::from(old_string.clone()));
+            params.insert("newString".into(), Value::from(new_string.clone()));
+            ("edit_file_v2".into(), Value::Object(params), Some(44))
         }
         other => {
             let (name, input) = other.to_canonical();
@@ -1060,11 +1101,33 @@ impl CursorDesktopStore {
                 continue;
             };
             let folder = ws.get("folder").and_then(Value::as_str).unwrap_or("");
-            if folder.strip_prefix("file://").is_some_and(|p| p == cwd) {
+            if matches_workspace_folder(folder, cwd) {
                 return entry.file_name().to_str().map(str::to_string);
             }
         }
         None
+    }
+}
+
+#[cfg(feature = "opencode")]
+fn matches_workspace_folder(folder: &str, cwd: &str) -> bool {
+    let Some(raw_path) = folder.strip_prefix("file://") else {
+        return false;
+    };
+    let decoded = raw_path.replace("%3A", ":").replace("%3a", ":");
+    normalize_path(&decoded) == normalize_path(cwd)
+}
+
+#[cfg(feature = "opencode")]
+fn normalize_path(s: &str) -> String {
+    let clean = s.trim_start_matches('/').replace('\\', "/");
+    #[cfg(windows)]
+    {
+        clean.to_ascii_lowercase()
+    }
+    #[cfg(not(windows))]
+    {
+        clean
     }
 }
 

--- a/src/harness/opencode.rs
+++ b/src/harness/opencode.rs
@@ -413,10 +413,12 @@ fn build_export(meta: &Meta, messages: &[Message]) -> Export {
                 }
             }
         }
-        out.push(MessageRecord {
-            info: Value::Object(info),
-            parts,
-        });
+        if !parts.is_empty() || matches!(msg.role, Role::Assistant) {
+            out.push(MessageRecord {
+                info: Value::Object(info),
+                parts,
+            });
+        }
         idx += 1;
     }
 
@@ -523,27 +525,27 @@ fn assistant_part(
                 "metadata": {},
                 "time": time,
             });
-            // Fold the immediately-following ToolResult into state.output.
+            // Fold matching ToolResult from the following user turn into state.output.
             if let Some(next) = messages.get(*idx + 1)
                 && matches!(next.role, Role::User)
-                && next.content.len() == 1
-                && let Block::ToolResult {
-                    tool_use_id,
-                    content,
-                    is_error,
-                } = &next.content[0]
-                && tool_use_id == id
+                && let Some(result) = next.content.iter().find_map(|b| match b {
+                    Block::ToolResult {
+                        tool_use_id,
+                        content,
+                        is_error,
+                    } if tool_use_id == id => Some((content, *is_error)),
+                    _ => None,
+                })
             {
                 if let Value::Object(obj) = &mut state {
-                    if *is_error {
+                    if result.1 {
                         obj.insert("status".into(), json!("error"));
-                        obj.insert("error".into(), json!(output_to_string(content)));
+                        obj.insert("error".into(), json!(output_to_string(result.0)));
                         obj.remove("output");
                     } else {
-                        obj.insert("output".into(), json!(output_to_string(content)));
+                        obj.insert("output".into(), json!(output_to_string(result.0)));
                     }
                 }
-                *idx += 1;
             }
             json!({ "type": "tool", "tool": oc_name, "callID": id, "state": state })
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -910,13 +910,17 @@ fn extract(meta: &Meta, messages: &[Message]) -> Vec<Line> {
                 // Images carry no searchable text.
                 Block::Image { .. } => {}
                 Block::Artifact { artifact } => {
-                    push(m, b, Origin::Assistant, &artifact.name);
+                    let origin = match message.role {
+                        Role::User => Origin::User,
+                        Role::Assistant => Origin::Assistant,
+                    };
+                    push(m, b, origin, &artifact.name);
                     match &artifact.source {
                         crate::common::ArtifactSource::Text { text, .. } => {
-                            push(m, b, Origin::Assistant, text);
+                            push(m, b, origin, text);
                         }
                         crate::common::ArtifactSource::Path { path, .. } => {
-                            push(m, b, Origin::Assistant, path);
+                            push(m, b, origin, path);
                         }
                         crate::common::ArtifactSource::Base64 { .. } => {}
                     }

--- a/tests/integration/cross_harness.rs
+++ b/tests/integration/cross_harness.rs
@@ -234,3 +234,89 @@ fn conversation_survives_every_hop() {
         "claude (round)"
     );
 }
+
+#[test]
+fn multi_tool_conversation_survives_cross_harness_conversion() {
+    let meta = common::Meta {
+        id: "multi-1".into(),
+        timestamp: ts("2026-01-02T03:04:05.000Z"),
+        cwd: Some("/repo".into()),
+        git_branch: None,
+        title: Some("MultiTool".into()),
+        cli_version: None,
+        model: Some("claude-opus-4-8".into()),
+    };
+    let body = vec![
+        common::Message {
+            role: common::Role::User,
+            content: vec![common::Block::Text {
+                text: "read files and edit".into(),
+            }],
+            timestamp: ts("2026-01-02T03:04:06.000Z"),
+            model: None,
+            stop_reason: None,
+            usage: None,
+        },
+        common::Message {
+            role: common::Role::Assistant,
+            content: vec![
+                common::Block::ToolUse {
+                    id: "call-1".into(),
+                    tool: common::Tool::Read {
+                        file_path: "/repo/a.rs".into(),
+                        offset: None,
+                        limit: None,
+                    },
+                },
+                common::Block::ToolUse {
+                    id: "call-2".into(),
+                    tool: common::Tool::Edit {
+                        file_path: "/repo/b.rs".into(),
+                        old_string: "foo".into(),
+                        new_string: "bar".into(),
+                        replace_all: false,
+                    },
+                },
+            ],
+            timestamp: ts("2026-01-02T03:04:07.000Z"),
+            model: Some("claude-opus-4-8".into()),
+            stop_reason: Some(common::StopReason::ToolUse),
+            usage: None,
+        },
+        common::Message {
+            role: common::Role::User,
+            content: vec![
+                common::Block::ToolResult {
+                    tool_use_id: "call-1".into(),
+                    content: common::ToolOutput::Text("file content a".into()),
+                    is_error: false,
+                },
+                common::Block::ToolResult {
+                    tool_use_id: "call-2".into(),
+                    content: common::ToolOutput::Text("edited b".into()),
+                    is_error: false,
+                },
+            ],
+            timestamp: ts("2026-01-02T03:04:08.000Z"),
+            model: None,
+            stop_reason: None,
+            usage: None,
+        },
+    ];
+    let common = Transcript::new(meta, body);
+    let expected = signature(&common);
+
+    let opencode = convert::<simple::Simple, opencode::OpenCode>(&simple::Simple::from_common(&common).unwrap()).unwrap();
+    assert_eq!(
+        signature(&opencode::OpenCode::to_common(&opencode).unwrap()),
+        expected,
+        "opencode multi-tool"
+    );
+
+    let cursor = convert::<simple::Simple, cursor::Cursor>(&simple::Simple::from_common(&common).unwrap()).unwrap();
+    assert_eq!(
+        signature(&cursor::Cursor::to_common(&cursor).unwrap()),
+        expected,
+        "cursor multi-tool"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes several cross-cutting tool argument mappings, parallel tool result folding, Windows workspace resolution, and search indexing origins across 5 key files in `txcript`.

## Motivation & Context
1. **Cursor CLI Tool Argument Asymmetry**: `normalize_cursor_args` converted `oldString`/`newString` to canonical `old_string`/`new_string`, but `denormalize_cursor_args` did not map them back, causing `Edit`/`StrReplace` tool calls to be emitted with unrecognized parameter keys in Cursor CLI sessions.
2. **Cursor Desktop Edit & Write Tools**: `denormalize_tool` in `cursor_desktop.rs` lacked mappings for `Tool::Write` (capability 43) and `Tool::Edit` (capability 44), falling through to `Tool::Raw` and breaking tool rendering in the Cursor desktop composer.
3. **OpenCode Parallel Tool Result Folding**: `part_from_common` in `opencode.rs` strictly required `next.content.len() == 1`, which failed whenever a model performed parallel tool calls in one turn. This caused tool outputs in multi-tool turns to become detached into orphaned user messages.
4. **Windows Cursor Desktop Workspace ID Resolution**: `workspace_id_for` compared stripped `file://` URIs against native Windows `cwd` paths without URL decode or path normalization (`/` vs `\`), causing imported sessions to fail workspace resolution on Windows.
5. **Search Artifact Origin Misclassification**: `extract` in `search.rs` hardcoded `Origin::Assistant` for all `Block::Artifact` entries instead of deriving the origin from `message.role`.

## Changes
- **`src/harness/cursor.rs`**: Added `old_string -> oldString` and `new_string -> newString` parameter mappings in `denormalize_cursor_args`.
- **`src/harness/cursor_desktop.rs`**:
  - Added `write_file_v2` and `edit_file_v2` in `normalize_tool` and `denormalize_tool` with capabilities `43` and `44`.
  - Added `matches_workspace_folder` and `normalize_path` to handle Windows path casing and percent-encoded URIs.
- **`src/harness/opencode.rs`**:
  - Updated `assistant_part` to look up matching `ToolResult`s within the user turn by `tool_use_id`, supporting parallel tool calls.
  - Skipped emitting empty user message containers when all tool results have been folded.
- **`src/search.rs`**:
  - Dynamically set `Origin::User` or `Origin::Assistant` for `Block::Artifact` based on `message.role`.
- **`tests/integration/cross_harness.rs`**:
  - Added `multi_tool_conversation_survives_cross_harness_conversion` integration test verifying multi-tool roundtrips across `Simple`, `OpenCode`, and `Cursor`.
