### PR TITLE
fix(search): derive artifact search origin from message role

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -910,13 +910,17 @@ fn extract(meta: &Meta, messages: &[Message]) -> Vec<Line> {
                 // Images carry no searchable text.
                 Block::Image { .. } => {}
                 Block::Artifact { artifact } => {
-                    push(m, b, Origin::Assistant, &artifact.name);
+                    let origin = match message.role {
+                        Role::User => Origin::User,
+                        Role::Assistant => Origin::Assistant,
+                    };
+                    push(m, b, origin, &artifact.name);
                     match &artifact.source {
                         crate::common::ArtifactSource::Text { text, .. } => {
-                            push(m, b, Origin::Assistant, text);
+                            push(m, b, origin, text);
                         }
                         crate::common::ArtifactSource::Path { path, .. } => {
-                            push(m, b, Origin::Assistant, path);
+                            push(m, b, origin, path);
                         }
                         crate::common::ArtifactSource::Base64 { .. } => {}
                     }


### PR DESCRIPTION
## Summary
Fixes search indexing in `src/search.rs` so that `Block::Artifact` entries are tagged with `Origin::User` or `Origin::Assistant` based on the enclosing `message.role`.

## Motivation & Context
In `src/search.rs`, `extract` previously hardcoded `Origin::Assistant` for all `Block::Artifact` instances. When user messages carried artifacts or file uploads, their contents and filenames were indexed under `Origin::Assistant`, causing queries filtering on `--origins user` / `Origin::User` to miss matches on user-supplied artifacts.

## Changes
- Updated `extract` in `src/search.rs` to set the line origin to `Origin::User` or `Origin::Assistant` matching `message.role`.
