### PR TITLE
fix(codec): preserve custom and unknown tool casing across OpenCode and Pi

### DIFF
--- a/docs/formats/pi.md
+++ b/docs/formats/pi.md
@@ -70,8 +70,8 @@ order, which is correct for the common single-branch session. Tool calls
 pair with results by `toolCallId`. Tool names normalize both ways: `bash` ↔
 `Bash`, `read`/`write` ↔ `Read`/`Write` (`path` ↔ `file_path`), `edit` ↔
 `Edit`/`MultiEdit` (`oldText`/`newText` ↔ `old_string`/`new_string`, one
-edit vs many), `find` ↔ `Glob`, `ls` ↔ `LS`, `grep` ↔ `Grep`; `mcp__*` names
-pass through untouched. `stopReason` maps `stop`/`length`/`toolUse`/`error`/
+edit vs many), `find` ↔ `Glob`, `ls` ↔ `LS`, `grep` ↔ `Grep`; unknown and MCP
+tool names pass through untouched. `stopReason` maps `stop`/`length`/`toolUse`/`error`/
 `aborted` onto the Common `StopReason` set; `usage` fields are `input`,
 `output`, `cacheRead`, `cacheWrite`.
 

--- a/src/harness/opencode.rs
+++ b/src/harness/opencode.rs
@@ -595,7 +595,7 @@ fn normalize_tool(tool: &str, input: Value) -> (String, Value) {
         "webfetch" => ("WebFetch".to_string(), input),
         "task" => ("Task".to_string(), input),
         "question" => ("Question".to_string(), input),
-        other => (title_case(other), input),
+        other => (other.to_string(), input),
     }
 }
 
@@ -630,7 +630,7 @@ fn denormalize_tool(name: &str, input: Value) -> (String, Value) {
         "WebFetch" => ("webfetch".to_string(), input),
         "Task" => ("task".to_string(), input),
         "Question" => ("question".to_string(), input),
-        other => (other.to_ascii_lowercase(), input),
+        other => (other.to_string(), input),
     }
 }
 
@@ -753,14 +753,6 @@ fn rename_keys(input: Value, renames: &[(&str, &str)]) -> Value {
         }
         // A non-object input has no keys to rename; pass it through untouched.
         other => other,
-    }
-}
-
-fn title_case(name: &str) -> String {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
-        None => String::new(),
     }
 }
 

--- a/src/harness/pi.rs
+++ b/src/harness/pi.rs
@@ -871,7 +871,7 @@ fn normalize_tool(tool: &str, input: Value) -> (String, Value) {
         "grep" => ("Grep".to_string(), input),
         "find" => ("Glob".to_string(), input),
         "ls" => ("LS".to_string(), input),
-        other => (title_case(other), input),
+        other => (other.to_string(), input),
     }
 }
 
@@ -979,7 +979,7 @@ fn denormalize_tool(tool: &Tool) -> (String, Value) {
         "Grep" => ("grep".to_string(), input),
         "Glob" => ("find".to_string(), input),
         "LS" => ("ls".to_string(), input),
-        other => (other.to_ascii_lowercase(), input),
+        other => (other.to_string(), input),
     }
 }
 
@@ -1044,14 +1044,6 @@ fn rename_keys(input: Value, renames: &[(&str, &str)]) -> Value {
         }
         // Non-object inputs have no keys to rename.
         other => other,
-    }
-}
-
-fn title_case(name: &str) -> String {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
-        None => String::new(),
     }
 }
 

--- a/tests/integration/cross_harness.rs
+++ b/tests/integration/cross_harness.rs
@@ -130,100 +130,168 @@ fn sample() -> Transcript<Common> {
     Transcript::new(meta, body)
 }
 
-#[test]
-fn conversation_survives_every_hop() {
-    let common = sample();
-    let expected = signature(&common);
+fn sample_with_raw_tool(tool_name: &str) -> Transcript<Common> {
+    let meta = common::Meta {
+        id: "x2".into(),
+        timestamp: ts("2026-01-02T03:04:05.000Z"),
+        cwd: Some("/repo".into()),
+        git_branch: None,
+        title: Some("Cross Raw".into()),
+        cli_version: None,
+        model: Some("claude-opus-4-8".into()),
+    };
+    let model = || Some("claude-opus-4-8".to_string());
+    let body = vec![
+        common::Message {
+            role: common::Role::User,
+            content: vec![common::Block::Text {
+                text: "execute action".into(),
+            }],
+            timestamp: ts("2026-01-02T03:04:06.000Z"),
+            model: None,
+            stop_reason: None,
+            usage: None,
+        },
+        common::Message {
+            role: common::Role::Assistant,
+            content: vec![common::Block::ToolUse {
+                id: "call-1".into(),
+                tool: common::Tool::Raw {
+                    tool_name: tool_name.into(),
+                    input: serde_json::json!({ "query": "txcript" }),
+                },
+            }],
+            timestamp: ts("2026-01-02T03:04:07.000Z"),
+            model: model(),
+            stop_reason: Some(common::StopReason::ToolUse),
+            usage: None,
+        },
+        common::Message {
+            role: common::Role::User,
+            content: vec![common::Block::ToolResult {
+                tool_use_id: "call-1".into(),
+                content: common::ToolOutput::Text("executed".into()),
+                is_error: false,
+            }],
+            timestamp: ts("2026-01-02T03:04:07.000Z"),
+            model: None,
+            stop_reason: None,
+            usage: None,
+        },
+        common::Message {
+            role: common::Role::Assistant,
+            content: vec![common::Block::Text {
+                text: "done".into(),
+            }],
+            timestamp: ts("2026-01-02T03:04:08.000Z"),
+            model: model(),
+            stop_reason: Some(common::StopReason::EndTurn),
+            usage: None,
+        },
+    ];
+    Transcript::new(meta, body)
+}
+
+fn assert_cycle(common: &Transcript<Common>, context: &str) {
+    let expected = signature(common);
 
     // Land it in Claude, then walk it across every harness via the hub.
-    let claude = claude_code::ClaudeCode::from_common(&common).unwrap();
+    let claude = claude_code::ClaudeCode::from_common(common).unwrap();
     assert_eq!(
         signature(&claude_code::ClaudeCode::to_common(&claude).unwrap()),
         expected,
-        "claude"
+        "{context}: claude"
     );
 
     let codex = convert::<claude_code::ClaudeCode, codex::Codex>(&claude).unwrap();
     assert_eq!(
         signature(&codex::Codex::to_common(&codex).unwrap()),
         expected,
-        "codex"
+        "{context}: codex"
     );
 
     let opencode = convert::<codex::Codex, opencode::OpenCode>(&codex).unwrap();
     assert_eq!(
         signature(&opencode::OpenCode::to_common(&opencode).unwrap()),
         expected,
-        "opencode"
+        "{context}: opencode"
     );
 
     let pi = convert::<opencode::OpenCode, pi::Pi>(&opencode).unwrap();
-    assert_eq!(signature(&pi::Pi::to_common(&pi).unwrap()), expected, "pi");
+    assert_eq!(
+        signature(&pi::Pi::to_common(&pi).unwrap()),
+        expected,
+        "{context}: pi"
+    );
 
     let campfire = convert::<pi::Pi, campfire::Campfire>(&pi).unwrap();
     assert_eq!(
         signature(&campfire::Campfire::to_common(&campfire).unwrap()),
         expected,
-        "campfire"
+        "{context}: campfire"
     );
 
     let cursor = convert::<campfire::Campfire, cursor::Cursor>(&campfire).unwrap();
     assert_eq!(
         signature(&cursor::Cursor::to_common(&cursor).unwrap()),
         expected,
-        "cursor"
+        "{context}: cursor"
     );
 
     let cursor_desktop = convert::<cursor::Cursor, cursor_desktop::CursorDesktop>(&cursor).unwrap();
     assert_eq!(
         signature(&cursor_desktop::CursorDesktop::to_common(&cursor_desktop).unwrap()),
         expected,
-        "cursor_desktop"
+        "{context}: cursor_desktop"
     );
 
     let grok = convert::<cursor_desktop::CursorDesktop, grok::Grok>(&cursor_desktop).unwrap();
     assert_eq!(
         signature(&grok::Grok::to_common(&grok).unwrap()),
         expected,
-        "grok"
+        "{context}: grok"
     );
 
     let fx = convert::<grok::Grok, fx::Fx>(&grok).unwrap();
-    assert_eq!(signature(&fx::Fx::to_common(&fx).unwrap()), expected, "fx");
+    assert_eq!(
+        signature(&fx::Fx::to_common(&fx).unwrap()),
+        expected,
+        "{context}: fx"
+    );
 
     let hermes = convert::<fx::Fx, hermes::Hermes>(&fx).unwrap();
     assert_eq!(
         signature(&hermes::Hermes::to_common(&hermes).unwrap()),
         expected,
-        "hermes"
+        "{context}: hermes"
     );
 
     let amp = convert::<hermes::Hermes, amp::Amp>(&hermes).unwrap();
     assert_eq!(
         signature(&amp::Amp::to_common(&amp).unwrap()),
         expected,
-        "amp"
+        "{context}: amp"
     );
 
     let antigravity = convert::<amp::Amp, antigravity::Antigravity>(&amp).unwrap();
     assert_eq!(
         signature(&antigravity::Antigravity::to_common(&antigravity).unwrap()),
         expected,
-        "antigravity"
+        "{context}: antigravity"
     );
 
     let simple = convert::<antigravity::Antigravity, simple::Simple>(&antigravity).unwrap();
     assert_eq!(
         signature(&simple::Simple::to_common(&simple).unwrap()),
         expected,
-        "simple"
+        "{context}: simple"
     );
 
     let cowork = convert::<simple::Simple, cowork::Cowork>(&simple).unwrap();
     assert_eq!(
         signature(&cowork::Cowork::to_common(&cowork).unwrap()),
         expected,
-        "cowork"
+        "{context}: cowork"
     );
 
     // And all the way back to Claude.
@@ -231,6 +299,23 @@ fn conversation_survives_every_hop() {
     assert_eq!(
         signature(&claude_code::ClaudeCode::to_common(&round).unwrap()),
         expected,
-        "claude (round)"
+        "{context}: claude (round)"
     );
+}
+
+#[test]
+fn conversation_survives_every_hop() {
+    assert_cycle(&sample(), "edit");
+}
+
+#[test]
+fn custom_tool_casing_survives_every_hop() {
+    for tool_name in [
+        "mcp__github__create_issue",
+        "custom_analyzer",
+        "WebSearch",
+        "myCustomTool",
+    ] {
+        assert_cycle(&sample_with_raw_tool(tool_name), tool_name);
+    }
 }

--- a/tests/integration/opencode.rs
+++ b/tests/integration/opencode.rs
@@ -251,3 +251,71 @@ fn codec_fixpoint_through_common_loses_nothing() {
     let back = opencode::OpenCode::to_common(&native).unwrap();
     assert_eq!(common, back);
 }
+
+#[test]
+fn custom_and_mcp_tool_names_preserve_exact_casing() {
+    let cases = [
+        "WebSearch",
+        "custom_linter",
+        "mcp__calc__add",
+        "camelCaseTool",
+    ];
+    for tool_name in cases {
+        let common = Transcript::new(
+            meta(),
+            vec![
+                common::Message {
+                    role: common::Role::User,
+                    content: vec![common::Block::Text {
+                        text: "run it".into(),
+                    }],
+                    timestamp: ts("2026-01-02T03:04:05.000Z"),
+                    model: None,
+                    stop_reason: None,
+                    usage: None,
+                },
+                common::Message {
+                    role: common::Role::Assistant,
+                    content: vec![common::Block::ToolUse {
+                        id: "call-1".into(),
+                        tool: common::Tool::Raw {
+                            tool_name: tool_name.into(),
+                            input: json!({ "query": "test" }),
+                        },
+                    }],
+                    timestamp: ts("2026-01-02T03:04:06.000Z"),
+                    model: Some("claude-opus-4-7".into()),
+                    stop_reason: Some(common::StopReason::ToolUse),
+                    usage: None,
+                },
+                common::Message {
+                    role: common::Role::User,
+                    content: vec![common::Block::ToolResult {
+                        tool_use_id: "call-1".into(),
+                        content: common::ToolOutput::Text("ok".into()),
+                        is_error: false,
+                    }],
+                    timestamp: ts("2026-01-02T03:04:06.000Z"),
+                    model: None,
+                    stop_reason: None,
+                    usage: None,
+                },
+            ],
+        );
+        let native = opencode::OpenCode::from_common(&common).unwrap();
+        let back = opencode::OpenCode::to_common(&native).unwrap();
+        match &back.body[1].content[0] {
+            common::Block::ToolUse {
+                tool:
+                    common::Tool::Raw {
+                        tool_name: back_name,
+                        ..
+                    },
+                ..
+            } => {
+                assert_eq!(back_name, tool_name, "tool name casing must be preserved");
+            }
+            other => panic!("expected Tool::Raw, got {other:?}"),
+        }
+    }
+}

--- a/tests/integration/pi.rs
+++ b/tests/integration/pi.rs
@@ -268,3 +268,80 @@ fn codec_fixpoint_through_common_loses_nothing() {
     let back = pi::Pi::to_common(&native).unwrap();
     assert_eq!(common, back);
 }
+
+#[test]
+fn custom_and_mcp_tool_names_preserve_exact_casing() {
+    let cases = [
+        "WebSearch",
+        "custom_linter",
+        "mcp__calc__add",
+        "camelCaseTool",
+    ];
+    for tool_name in cases {
+        let meta = common::Meta {
+            id: "pi-casing".into(),
+            timestamp: ts("2026-01-02T03:04:05.000Z"),
+            cwd: Some("/repo".into()),
+            git_branch: None,
+            title: Some("Casing".into()),
+            cli_version: None,
+            model: Some("claude-opus-4-8".into()),
+        };
+        let common = Transcript::new(
+            meta,
+            vec![
+                common::Message {
+                    role: common::Role::User,
+                    content: vec![common::Block::Text {
+                        text: "run tool".into(),
+                    }],
+                    timestamp: ts("2026-01-02T03:04:05.000Z"),
+                    model: None,
+                    stop_reason: None,
+                    usage: None,
+                },
+                common::Message {
+                    role: common::Role::Assistant,
+                    content: vec![common::Block::ToolUse {
+                        id: "call-1".into(),
+                        tool: common::Tool::Raw {
+                            tool_name: tool_name.into(),
+                            input: serde_json::json!({ "arg": 42 }),
+                        },
+                    }],
+                    timestamp: ts("2026-01-02T03:04:06.000Z"),
+                    model: Some("claude-opus-4-8".into()),
+                    stop_reason: Some(common::StopReason::ToolUse),
+                    usage: None,
+                },
+                common::Message {
+                    role: common::Role::User,
+                    content: vec![common::Block::ToolResult {
+                        tool_use_id: "call-1".into(),
+                        content: common::ToolOutput::Text("success".into()),
+                        is_error: false,
+                    }],
+                    timestamp: ts("2026-01-02T03:04:07.000Z"),
+                    model: None,
+                    stop_reason: None,
+                    usage: None,
+                },
+            ],
+        );
+        let native = pi::Pi::from_common(&common).unwrap();
+        let back = pi::Pi::to_common(&native).unwrap();
+        match &back.body[1].content[0] {
+            common::Block::ToolUse {
+                tool:
+                    common::Tool::Raw {
+                        tool_name: back_name,
+                        ..
+                    },
+                ..
+            } => {
+                assert_eq!(back_name, tool_name, "pi must preserve tool name casing");
+            }
+            other => panic!("expected Tool::Raw, got {other:?}"),
+        }
+    }
+}

--- a/tests/integration/properties.rs
+++ b/tests/integration/properties.rs
@@ -79,15 +79,22 @@ fn arb_tool() -> impl Strategy<Value = Tool> {
             description: None,
             run_in_background: false,
         }),
-        // A name no harness types, so it can't normalize into a typed tool.
-        // Title-case-shaped only: opencode lowercases unknown names on write
-        // and title-cases on read, so any other shape (`mcp__x`, `WebSearch`)
-        // does not round-trip through it today — a known codec bug this
-        // generator excludes rather than hides behind a looser assertion.
-        ("Custom_[a-z]{1,8}", arb_text()).prop_map(|(tool_name, note)| Tool::Raw {
-            tool_name,
-            input: json!({ "note": note }),
-        }),
+        // Names no harness types, with arbitrary casing: snake_case, camelCase,
+        // PascalCase, and MCP namespaces (`mcp__...`), all of which round-trip
+        // losslessly across every codec.
+        (
+            prop_oneof![
+                "Custom_[A-Za-z0-9_]{1,10}",
+                "custom_[a-z0-9_]{1,10}",
+                "mcp__[a-z]{1,6}__[a-z]{1,8}",
+                "rawTool[A-Za-z0-9]{1,8}",
+            ],
+            arb_text(),
+        )
+            .prop_map(|(tool_name, note)| Tool::Raw {
+                tool_name,
+                input: json!({ "note": note }),
+            }),
     ]
 }
 


### PR DESCRIPTION
## Summary
Fixes an asymmetric tool name casing bug in `OpenCode` and `Pi` (and by extension `Campfire`) that caused unknown tools, Model Context Protocol (MCP) tools, snake_case tools, camelCase tools, and custom tools with uppercase letters to fail round-tripping through `from_common` / `to_common`.

## Problem & Root Cause
In `txcript`, each codec is designed to convert transcripts losslessly between native schemas and `Transcript<Common>`. Unknown or MCP tools are represented in Common as `Tool::Raw { tool_name, input }` so their names and arguments remain completely intact.

However, `OpenCode` (`src/harness/opencode.rs`) and `Pi` (`src/harness/pi.rs`) unilaterally modified the casing of unknown tool names:
1. **On Read (`normalize_tool`)**: Both harnesses applied `title_case(other)`, forcing the first ASCII letter to uppercase (`mcp__calc__add` → `Mcp__calc__add`, `custom_linter` → `Custom_linter`, `web_search` → `Web_search`).
2. **On Write (`denormalize_tool`)**: Both harnesses applied `other.to_ascii_lowercase()`, downcasing all characters (`WebSearch` → `websearch`, `myTool` → `mytool`).

Because of this codec asymmetry:
- MCP tools and custom tools with non-title-case shapes failed to round-trip.
- In `tests/integration/properties.rs`, the property-based invariance generator had to explicitly exclude non-title-case tool names with an inline explanation:
  ```rust
  // Title-case-shaped only: opencode lowercases unknown names on write
  // and title-cases on read, so any other shape (`mcp__x`, `WebSearch`)
  // does not round-trip through it today — a known codec bug this
  // generator excludes rather than hides behind a looser assertion.
  ("Custom_[a-z]{1,8}", arb_text())
  ```
- Multi-hop cross-harness conversion tests (`cross_harness.rs`) only verified `Tool::Edit`, leaving custom tools untested across harness boundaries.

## Key Changes
1. **`src/harness/opencode.rs`**:
   - In `normalize_tool`: Pass unknown tool names through verbatim (`other => (other.to_string(), input)`).
   - In `denormalize_tool`: Pass unknown tool names through verbatim (`other => (other.to_string(), input)`).
   - Removed dead helper `fn title_case`.
2. **`src/harness/pi.rs`**:
   - In `normalize_tool`: Pass unknown tool names through verbatim (`other => (other.to_string(), input)`).
   - In `denormalize_tool`: Pass unknown tool names through verbatim (`other => (other.to_string(), input)`).
   - Removed dead helper `fn title_case`.
3. **`tests/integration/properties.rs`**:
   - Expanded `arb_tool()` generator to generate arbitrary tool naming conventions (PascalCase `Custom_[A-Za-z0-9_]`, snake_case `custom_[a-z0-9_]`, MCP namespaces `mcp__[a-z]__[a-z]`, and camelCase `rawTool[A-Za-z0-9]`).
   - Removed the codec bug exemption; verified that every codec preserves these tool names.
4. **`tests/integration/cross_harness.rs`**:
   - Factored the 14-harness hop sequence into `assert_cycle(common, context)`.
   - Added `custom_tool_casing_survives_every_hop` testing `mcp__github__create_issue`, `custom_analyzer`, `WebSearch`, and `myCustomTool` across Claude → Codex → OpenCode → Pi → Campfire → Cursor → Cursor Desktop → Grok → Fx → Hermes → Amp → Antigravity → Simple → Cowork → Claude.
5. **`tests/integration/opencode.rs`**:
   - Added `custom_and_mcp_tool_names_preserve_exact_casing` test verifying casing preservation for `WebSearch`, `custom_linter`, `mcp__calc__add`, and `camelCaseTool`.
6. **`tests/integration/pi.rs`**:
   - Added `custom_and_mcp_tool_names_preserve_exact_casing` test verifying casing preservation for `WebSearch`, `custom_linter`, `mcp__calc__add`, and `camelCaseTool`.
7. **`docs/formats/pi.md`**:
   - Updated documentation to specify that unknown and MCP tool names pass through untouched.

## Verification
- `cargo fmt --all -- --check`: PASS
- `cargo clippy -p txcript --no-default-features --features opencode,hermes,search --all-targets`: PASS (clean, 0 warnings)
- `cargo test -p txcript --no-default-features --features opencode,hermes,search --test integration`: PASS (all 165 tests passed, including `opencode`, `pi`, `cross_harness`, and `properties`)
- `cargo test -p txcript --no-default-features --features opencode,hermes,search --test regression`: PASS (all 5 regression tests passed)
