### PR TITLE
fix(store): enforce containment and path validation on delete across file-backed stores

### DIFF
--- a/src/harness/amp.rs
+++ b/src/harness/amp.rs
@@ -1081,8 +1081,28 @@ impl Store for AmpStore {
         })
     }
 
+    /// Removes an Amp thread document. Guarded on shape and containment: the
+    /// reference must be a `.json` file resolving directly under `threads_dir`,
+    /// so a foreign or stale reference never removes an unrelated file.
     fn delete(&self, reference: &PathBuf) -> Result<()> {
-        Ok(fs::remove_file(reference)?)
+        if reference.extension().is_none_or(|ext| ext != "json") {
+            return Err(Error::Malformed {
+                harness: Amp::NAME,
+                detail: format!("not an amp thread file: {}", reference.display()),
+            });
+        }
+        let canon = reference.canonicalize()?;
+        let threads_dir = self.threads_dir.canonicalize()?;
+        if canon.parent() != Some(threads_dir.as_path()) {
+            return Err(Error::Malformed {
+                harness: Amp::NAME,
+                detail: format!(
+                    "refusing to delete outside the threads root: {}",
+                    reference.display()
+                ),
+            });
+        }
+        Ok(fs::remove_file(canon)?)
     }
 
     fn fingerprints(&self, refs: &[PathBuf]) -> Result<HashMap<String, String>> {

--- a/src/harness/campfire.rs
+++ b/src/harness/campfire.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::harness::jsonl;
 use crate::harness::pi::{self, Record};
 use crate::transcript::{Codec, Common, Discovered, Harness, Saved, Store, TextCodec, Transcript};
@@ -82,7 +82,27 @@ impl Store for CampfireStore {
         pi::write_session(&self.sessions_dir, &transcript.meta, &transcript.body)
     }
 
+    /// Removes a Campfire session log. Guarded on shape and containment:
+    /// the reference must be a `.jsonl` file resolving within `sessions_dir`,
+    /// so a foreign or stale reference never removes files outside the sessions root.
     fn delete(&self, reference: &PathBuf) -> Result<()> {
-        Ok(std::fs::remove_file(reference)?)
+        if reference.extension().is_none_or(|ext| ext != "jsonl") {
+            return Err(Error::Malformed {
+                harness: Campfire::NAME,
+                detail: format!("not a campfire session file: {}", reference.display()),
+            });
+        }
+        let canon = reference.canonicalize()?;
+        let sessions = self.sessions_dir.canonicalize()?;
+        if canon.strip_prefix(&sessions).is_err() || canon == sessions {
+            return Err(Error::Malformed {
+                harness: Campfire::NAME,
+                detail: format!(
+                    "refusing to delete outside the sessions root: {}",
+                    reference.display()
+                ),
+            });
+        }
+        Ok(std::fs::remove_file(canon)?)
     }
 }

--- a/src/harness/claude_code.rs
+++ b/src/harness/claude_code.rs
@@ -495,8 +495,28 @@ impl Store for ClaudeStore {
         })
     }
 
+    /// Removes a Claude Code session log. Guarded on shape and containment:
+    /// the reference must be a `.jsonl` file resolving within `root`, so a
+    /// foreign or stale reference never removes files outside the configured projects.
     fn delete(&self, reference: &PathBuf) -> Result<()> {
-        Ok(fs::remove_file(reference)?)
+        if reference.extension().is_none_or(|ext| ext != "jsonl") {
+            return Err(Error::Malformed {
+                harness: ClaudeCode::NAME,
+                detail: format!("not a claude code session file: {}", reference.display()),
+            });
+        }
+        let canon = reference.canonicalize()?;
+        let root = self.root.canonicalize()?;
+        if canon.strip_prefix(&root).is_err() || canon == root {
+            return Err(Error::Malformed {
+                harness: ClaudeCode::NAME,
+                detail: format!(
+                    "refusing to delete outside the projects root: {}",
+                    reference.display()
+                ),
+            });
+        }
+        Ok(fs::remove_file(canon)?)
     }
 
     fn fingerprints(&self, refs: &[PathBuf]) -> Result<HashMap<String, String>> {

--- a/src/harness/codex.rs
+++ b/src/harness/codex.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 
 use crate::common::{Block, ImageSource, Message, Meta, Role, Tool, ToolOutput, Usage};
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::harness::jsonl;
 use crate::transcript::{Codec, Common, Discovered, Harness, Saved, Store, TextCodec, Transcript};
 
@@ -767,8 +767,28 @@ impl Store for CodexStore {
         })
     }
 
+    /// Removes a Codex rollout log. Guarded on shape and containment:
+    /// the reference must be a `.jsonl` file resolving within `sessions_dir`,
+    /// so a foreign or stale reference never removes files outside the sessions root.
     fn delete(&self, reference: &PathBuf) -> Result<()> {
-        Ok(fs::remove_file(reference)?)
+        if reference.extension().is_none_or(|ext| ext != "jsonl") {
+            return Err(Error::Malformed {
+                harness: Codex::NAME,
+                detail: format!("not a codex session file: {}", reference.display()),
+            });
+        }
+        let canon = reference.canonicalize()?;
+        let sessions = self.sessions_dir.canonicalize()?;
+        if canon.strip_prefix(&sessions).is_err() || canon == sessions {
+            return Err(Error::Malformed {
+                harness: Codex::NAME,
+                detail: format!(
+                    "refusing to delete outside the sessions root: {}",
+                    reference.display()
+                ),
+            });
+        }
+        Ok(fs::remove_file(canon)?)
     }
 
     fn fingerprints(&self, refs: &[PathBuf]) -> Result<HashMap<String, String>> {

--- a/src/harness/pi.rs
+++ b/src/harness/pi.rs
@@ -21,7 +21,7 @@ use serde_json::{Map, Value, json};
 use uuid::Uuid;
 
 use crate::common::{Block, ImageSource, Message, Meta, Role, StopReason, Tool, ToolOutput, Usage};
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::harness::jsonl;
 use crate::transcript::{Codec, Common, Discovered, Harness, Saved, Store, TextCodec, Transcript};
 
@@ -427,8 +427,28 @@ impl Store for PiStore {
         write_session(&self.sessions_dir, &transcript.meta, &transcript.body)
     }
 
+    /// Removes a Pi session log. Guarded on shape and containment:
+    /// the reference must be a `.jsonl` file resolving within `sessions_dir`,
+    /// so a foreign or stale reference never removes files outside the sessions root.
     fn delete(&self, reference: &PathBuf) -> Result<()> {
-        Ok(std::fs::remove_file(reference)?)
+        if reference.extension().is_none_or(|ext| ext != "jsonl") {
+            return Err(Error::Malformed {
+                harness: Pi::NAME,
+                detail: format!("not a pi session file: {}", reference.display()),
+            });
+        }
+        let canon = reference.canonicalize()?;
+        let sessions = self.sessions_dir.canonicalize()?;
+        if canon.strip_prefix(&sessions).is_err() || canon == sessions {
+            return Err(Error::Malformed {
+                harness: Pi::NAME,
+                detail: format!(
+                    "refusing to delete outside the sessions root: {}",
+                    reference.display()
+                ),
+            });
+        }
+        Ok(std::fs::remove_file(canon)?)
     }
 
     fn fingerprints(&self, refs: &[PathBuf]) -> Result<HashMap<String, String>> {

--- a/tests/integration/path_safety.rs
+++ b/tests/integration/path_safety.rs
@@ -7,7 +7,9 @@ use std::path::{Path, PathBuf};
 
 use chrono::{TimeZone, Utc};
 use txcript::common::{Block, Message, Meta, Role};
-use txcript::harness::{amp, antigravity, campfire, claude_code, codex, cursor, grok, pi};
+use txcript::harness::{
+    amp, antigravity, campfire, claude_code, codex, cowork, cursor, fx, grok, pi,
+};
 use txcript::{Codec, Common, Store, Transcript};
 
 fn small_common(id: &str) -> Transcript<Common> {
@@ -85,6 +87,12 @@ fn hostile_ids_cannot_escape_any_file_backed_store() {
         &antigravity::AntigravityStore::new(root.to_path_buf()),
         root,
     );
+    assert_save_confined(&fx::FxStore::new(root.to_path_buf()), root);
+    let cowork_account = root
+        .join("11111111-1111-1111-1111-111111111111")
+        .join("22222222-2222-2222-2222-222222222222");
+    std::fs::create_dir_all(&cowork_account).unwrap();
+    assert_save_confined(&cowork::CoworkStore::new(root.to_path_buf()), root);
 }
 
 #[test]
@@ -177,6 +185,118 @@ fn antigravity_delete_refuses_paths_outside_the_conversations_root() {
         "a .db outside the conversations root must be refused"
     );
     assert!(foreign_db.is_file(), "the foreign file must survive");
+}
+
+#[test]
+fn amp_delete_refuses_paths_outside_the_threads_root() {
+    let threads = tempfile::tempdir().unwrap();
+    let victim = tempfile::tempdir().unwrap();
+    let foreign = victim.path().join("thread.json");
+    std::fs::write(&foreign, b"{}").unwrap();
+
+    let store = amp::AmpStore::new(threads.path().to_path_buf());
+    assert!(
+        store.delete(&foreign).is_err(),
+        "a thread.json outside the threads root must be refused"
+    );
+    assert!(victim.path().is_dir(), "the foreign directory must survive");
+    assert!(foreign.is_file(), "the foreign file must survive");
+}
+
+#[test]
+fn claude_delete_refuses_paths_outside_the_projects_root() {
+    let projects = tempfile::tempdir().unwrap();
+    let victim = tempfile::tempdir().unwrap();
+    let foreign = victim.path().join("session.jsonl");
+    std::fs::write(&foreign, b"{}").unwrap();
+
+    let store = claude_code::ClaudeStore::new(projects.path().to_path_buf());
+    assert!(
+        store.delete(&foreign).is_err(),
+        "a session.jsonl outside the projects root must be refused"
+    );
+    assert!(victim.path().is_dir(), "the foreign directory must survive");
+    assert!(foreign.is_file(), "the foreign file must survive");
+}
+
+#[test]
+fn codex_delete_refuses_paths_outside_the_sessions_root() {
+    let sessions = tempfile::tempdir().unwrap();
+    let victim = tempfile::tempdir().unwrap();
+    let foreign = victim.path().join("rollout.jsonl");
+    std::fs::write(&foreign, b"{}").unwrap();
+
+    let store = codex::CodexStore::new(sessions.path().to_path_buf());
+    assert!(
+        store.delete(&foreign).is_err(),
+        "a rollout.jsonl outside the sessions root must be refused"
+    );
+    assert!(victim.path().is_dir(), "the foreign directory must survive");
+    assert!(foreign.is_file(), "the foreign file must survive");
+}
+
+#[test]
+fn pi_delete_refuses_paths_outside_the_sessions_root() {
+    let sessions = tempfile::tempdir().unwrap();
+    let victim = tempfile::tempdir().unwrap();
+    let foreign = victim.path().join("session.jsonl");
+    std::fs::write(&foreign, b"{}").unwrap();
+
+    let store = pi::PiStore::new(sessions.path().to_path_buf());
+    assert!(
+        store.delete(&foreign).is_err(),
+        "a session.jsonl outside the sessions root must be refused"
+    );
+    assert!(victim.path().is_dir(), "the foreign directory must survive");
+    assert!(foreign.is_file(), "the foreign file must survive");
+}
+
+#[test]
+fn campfire_delete_refuses_paths_outside_the_sessions_root() {
+    let sessions = tempfile::tempdir().unwrap();
+    let victim = tempfile::tempdir().unwrap();
+    let foreign = victim.path().join("session.jsonl");
+    std::fs::write(&foreign, b"{}").unwrap();
+
+    let store = campfire::CampfireStore::new(sessions.path().to_path_buf());
+    assert!(
+        store.delete(&foreign).is_err(),
+        "a session.jsonl outside the sessions root must be refused"
+    );
+    assert!(victim.path().is_dir(), "the foreign directory must survive");
+    assert!(foreign.is_file(), "the foreign file must survive");
+}
+
+#[test]
+fn fx_delete_refuses_paths_outside_the_sessions_root() {
+    let sessions = tempfile::tempdir().unwrap();
+    let victim = tempfile::tempdir().unwrap();
+    let events = victim.path().join("events.jsonl");
+    std::fs::write(&events, b"").unwrap();
+
+    let store = fx::FxStore::new(sessions.path().to_path_buf());
+    assert!(
+        store.delete(&victim.path().to_path_buf()).is_err(),
+        "an fx session outside the sessions root must be refused"
+    );
+    assert!(victim.path().is_dir(), "the foreign directory must survive");
+    assert!(events.is_file(), "the foreign file must survive");
+}
+
+#[test]
+fn cowork_delete_refuses_paths_outside_the_sessions_root() {
+    let root = tempfile::tempdir().unwrap();
+    let victim = tempfile::tempdir().unwrap();
+    let foreign = victim.path().join("local_session.json");
+    std::fs::write(&foreign, b"{}").unwrap();
+
+    let store = cowork::CoworkStore::new(root.path().to_path_buf());
+    assert!(
+        store.delete(&foreign).is_err(),
+        "a cowork record outside the root must be refused"
+    );
+    assert!(victim.path().is_dir(), "the foreign directory must survive");
+    assert!(foreign.is_file(), "the foreign file must survive");
 }
 
 #[cfg(unix)]

--- a/tests/integration/store_delete.rs
+++ b/tests/integration/store_delete.rs
@@ -4,7 +4,7 @@
 
 use chrono::{TimeZone, Utc};
 use txcript::common::{Block, Message, Meta, Role};
-use txcript::harness::{campfire, claude_code, codex, grok, pi};
+use txcript::harness::{amp, antigravity, campfire, claude_code, codex, grok, pi};
 use txcript::{Codec, Common, Store, Transcript};
 
 #[cfg(feature = "opencode")]
@@ -91,6 +91,75 @@ fn pi_delete_roundtrip() {
 fn campfire_delete_roundtrip() {
     let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
     roundtrip(&campfire::CampfireStore::new(dir.path().to_path_buf()));
+}
+
+#[test]
+fn amp_delete_roundtrip() {
+    let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+    roundtrip(&amp::AmpStore::new(dir.path().to_path_buf()));
+}
+
+#[test]
+fn antigravity_delete_roundtrip() {
+    let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+    roundtrip(&antigravity::AntigravityStore::new(
+        dir.path().to_path_buf(),
+    ));
+}
+
+#[test]
+fn amp_delete_refuses_a_non_session_path() {
+    let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+    let store = amp::AmpStore::new(dir.path().to_path_buf());
+    assert!(
+        store
+            .delete(&dir.path().join("somewhere/else.json"))
+            .is_err()
+    );
+}
+
+#[test]
+fn claude_code_delete_refuses_a_non_session_path() {
+    let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+    let store = claude_code::ClaudeStore::new(dir.path().to_path_buf());
+    assert!(
+        store
+            .delete(&dir.path().join("somewhere/else.jsonl"))
+            .is_err()
+    );
+}
+
+#[test]
+fn codex_delete_refuses_a_non_session_path() {
+    let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+    let store = codex::CodexStore::new(dir.path().to_path_buf());
+    assert!(
+        store
+            .delete(&dir.path().join("somewhere/else.jsonl"))
+            .is_err()
+    );
+}
+
+#[test]
+fn pi_delete_refuses_a_non_session_path() {
+    let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+    let store = pi::PiStore::new(dir.path().to_path_buf());
+    assert!(
+        store
+            .delete(&dir.path().join("somewhere/else.jsonl"))
+            .is_err()
+    );
+}
+
+#[test]
+fn campfire_delete_refuses_a_non_session_path() {
+    let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+    let store = campfire::CampfireStore::new(dir.path().to_path_buf());
+    assert!(
+        store
+            .delete(&dir.path().join("somewhere/else.jsonl"))
+            .is_err()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Hardens `Store::delete` across all remaining file-backed stores (`AmpStore`, `ClaudeStore`, `CodexStore`, `PiStore`, and `CampfireStore`) by enforcing strict path containment and file format validation, preventing arbitrary file deletion outside the store root.

## Problem
While `AntigravityStore`, `CursorStore`, `GrokStore`, `FxStore`, and `CoworkStore` enforce strict containment invariants on `Store::delete`, the remaining file-backed stores (`AmpStore`, `ClaudeStore`, `CodexStore`, `PiStore`, and `CampfireStore`) previously executed raw `fs::remove_file(reference)` without validating:
1. That the target path canonicalizes within the store's configured root directory.
2. That the target path is a file and possesses the expected extension (`.json` for Amp, `.jsonl` for Claude Code, Codex, Pi, and Campfire).

Consequently, any foreign reference passed to `delete` (from stale state, adversarial transcript input, or misconfigured paths) could delete arbitrary files on the filesystem.

Furthermore:
- `tests/integration/path_safety.rs` only tested `CursorStore`, `GrokStore`, and `AntigravityStore` for delete refusal, omitting `AmpStore`, `ClaudeStore`, `CodexStore`, `PiStore`, `CampfireStore`, `FxStore`, and `CoworkStore`.
- `tests/integration/store_delete.rs` lacked delete roundtrip tests for `AmpStore` and `AntigravityStore`, as well as non-session path refusal tests.

## Solution
1. **`AmpStore::delete`**: Verify `reference.extension() == "json"`, resolve canonical path, ensure `canon.parent() == Some(threads_dir.as_path())`, and reject foreign paths with `Error::Malformed`.
2. **`ClaudeStore::delete`**: Verify `reference.extension() == "jsonl"`, resolve canonical path, ensure `canon.strip_prefix(&root).is_ok()` and `canon != root`, and reject foreign paths with `Error::Malformed`.
3. **`CodexStore::delete`**: Verify `reference.extension() == "jsonl"`, resolve canonical path, ensure `canon.strip_prefix(&sessions).is_ok()` and `canon != sessions`, and reject foreign paths with `Error::Malformed`.
4. **`PiStore::delete`**: Verify `reference.extension() == "jsonl"`, resolve canonical path, ensure `canon.strip_prefix(&sessions).is_ok()` and `canon != sessions`, and reject foreign paths with `Error::Malformed`.
5. **`CampfireStore::delete`**: Verify `reference.extension() == "jsonl"`, resolve canonical path, ensure `canon.strip_prefix(&sessions).is_ok()` and `canon != sessions`, and reject foreign paths with `Error::Malformed`.
6. **Path Safety & Store Delete Tests**:
   - Added delete refusal tests for `AmpStore`, `ClaudeStore`, `CodexStore`, `PiStore`, `CampfireStore`, `FxStore`, and `CoworkStore` in `tests/integration/path_safety.rs`.
   - Added `FxStore` and `CoworkStore` to `hostile_ids_cannot_escape_any_file_backed_store`.
   - Added `AmpStore` and `AntigravityStore` roundtrip tests in `tests/integration/store_delete.rs`, along with non-session path refusal assertions.

## Verification
- `cargo test -p txcript --no-default-features --features opencode,hermes,search --test integration` (all 176 integration tests pass)
- `cargo clippy -p txcript --no-default-features --features opencode,hermes,search --all-targets -- -D warnings` (clean, zero warnings)
- `cargo fmt --all -- --check` (clean)
