### PR TITLE
feat(cli): support Simple interchange documents across view, export, and crop

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,18 +147,18 @@ txcript continue <id>[#range]            # continue <id>, then launch its harnes
     [--no-resume]                         #   write the session but don't launch
 txcript continue <file|->[#range]        # continue a Simple document instead:
     --with <harness> [...]                #   a file, or stdin (`-`), from any agent
-txcript crop <id>[#range]                # interactively cut messages and save a copy
+txcript crop <id|file>[#range]           # interactively cut messages and save a copy
     [--with <harness>]                    #   optionally convert the cropped copy
     [--from <harness>]                    #   scope the source lookup
-txcript view <id>[#range]                # view a session; compact text when piped
+txcript view <id|file|->[#range]         # view a session; compact text when piped
     [--from <harness>]                    #   scope the id lookup to one harness
     [--no-pager]                          #   print the terminal view directly
-txcript export <id>[#range]              # write a session as a Simple document
+txcript export <id|file|->[#range]       # write a session as a Simple document
     [--from <harness>]                    #   scope the id lookup to one harness
     [--out <file>]                        #   write to <file> instead of stdout
 ```
 
-A session id is any unambiguous prefix of the full id, or the session's exact title. `txcript resume` is an alias for `continue`. `--since` and `--until` take RFC 3339 timestamps or bare `YYYY-MM-DD` dates.
+A session id is any unambiguous prefix of the full id, or the session's exact title. `txcript resume` is an alias for `continue`. `--since` and `--until` take RFC 3339 timestamps or bare `YYYY-MM-DD` dates. `view`, `export`, and `crop` accept Simple document files directly (and `view`/`export` accept stdin `-`), resolving `#range` fragments identically to local sessions.
 
 `continue` writes the session where the target harness keeps its sessions, then launches that harness on it, handing over the terminal:
 
@@ -174,9 +174,9 @@ A session id is any unambiguous prefix of the full id, or the session's exact ti
 - `abc#5-`: message 5 to the end
 - `abc#-10`: start through message 10
 
-`continue` accepts the same suffix and continues just those messages as a new session. `crop` opens an interactive editor over the session, in the spirit of a video editor's timeline: every message starts out kept, and you remove the ones you don't want from anywhere in the conversation, not just the ends. Move with `j`/`k` or the arrow keys and press Space to remove the message under the cursor (or restore it). To work on a stretch at once, press `v`, move to the other end, then `x` to remove it, `r` to restore it, or `t` to keep only that stretch; `:3-10` selects a range by number and `:42` jumps to a message. `e` opens the message under the cursor in your editor (`$VISUAL`, `$EDITOR`, or `vi`) as plain text, one heading per block: change the text, trim a tool result, or empty a block to drop it, then save and quit to apply. A terminal editor runs in a pane beside or under the transcript; `E` gives it the whole terminal instead, and an editor that opens its own window is waited for. `u` undoes, `U` redoes, `?` lists every key. Removed messages collapse to their header, edited ones say so, and an overview of the whole session, one cell per message, runs down the right edge or along the bottom depending on the window's shape. Enter saves the kept messages, edits included, as a new session; `q` leaves without saving. A `#range` is optional and opens the editor with only that range kept. The copy defaults to the source harness unless `--with` selects another one, and the source is never modified. A tool call and its result are always removed or restored together, so the saved copy never splits them.
+`continue` accepts the same suffix and continues just those messages as a new session. `crop` opens an interactive editor over the session, in the spirit of a video editor's timeline: every message starts out kept, and you remove the ones you don't want from anywhere in the conversation, not just the ends. Move with `j`/`k` or the arrow keys and press Space to remove the message under the cursor (or restore it). To work on a stretch at once, press `v`, move to the other end, then `x` to remove it, `r` to restore it, or `t` to keep only that stretch; `:3-10` selects a range by number and `:42` jumps to a message. `e` opens the message under the cursor in your editor (`$VISUAL`, `$EDITOR`, or `vi`) as plain text, one heading per block: change the text, trim a tool result, or empty a block to drop it, then save and quit to apply. A terminal editor runs in a pane beside or under the transcript; `E` gives it the whole terminal instead, and an editor that opens its own window is waited for. `u` undoes, `U` redoes, `?` lists every key. Removed messages collapse to their header, edited ones say so, and an overview of the whole session, one cell per message, runs down the right edge or along the bottom depending on the window's shape. Enter saves the kept messages, edits included, as a new session; `q` leaves without saving. A `#range` is optional and opens the editor with only that range kept. The copy defaults to the source harness unless `--with` selects another one (required when cropping a Simple document), and the source is never modified. A tool call and its result are always removed or restored together, so the saved copy never splits them.
 
-`export` writes the session as a [Simple](docs/formats/simple.md) document, to stdout or `--out <file>`. The document is the full rendering of the canonical model — everything `continue` carries between harnesses — detached from any harness's store, so it moves between machines as a file:
+`export` writes the session as a [Simple](docs/formats/simple.md) document, to stdout or `--out <file>` (and can re-slice or re-format an existing document). The document is the full rendering of the canonical model — everything `continue` carries between harnesses — detached from any harness's store, so it moves between machines as a file:
 
 ```sh
 txcript export 0dc114bf --out session.json       # on this machine

--- a/cli/src/export.rs
+++ b/cli/src/export.rs
@@ -1,11 +1,12 @@
 //! `txcript export` — write a session as a Simple interchange document.
 //!
-//! The source is resolved exactly like `view` (id or exact title, optional
-//! `#range`). The output is the full-fidelity Simple rendering of the
-//! canonical model — every `Transcript<Common>` field has a slot in Simple —
-//! so the document is the session as txcript sees it, detached from any
-//! harness's store. `txcript continue <file> --with <harness>` brings it
-//! back into a harness, on this machine or another.
+//! The source is resolved exactly like `view` (id, exact title, or an existing
+//! Simple document file or stdin `-`, with optional `#range`). The output is the
+//! full-fidelity Simple rendering of the canonical model — every
+//! `Transcript<Common>` field has a slot in Simple — so the document is the
+//! session as txcript sees it, detached from any harness's store.
+//! `txcript continue <file> --with <harness>` brings it back into a harness,
+//! on this machine or another.
 
 use std::path::Path;
 use std::process::ExitCode;
@@ -177,5 +178,33 @@ mod tests {
         let parsed = Simple::from_text(&text).unwrap();
         let back = Simple::to_common(&parsed).unwrap();
         assert_eq!(back, original);
+    }
+
+    #[test]
+    fn cmd_export_slices_existing_simple_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let input_path = dir.path().join("input.json");
+        let output_path = dir.path().join("sliced.json");
+        std::fs::write(
+            &input_path,
+            r#"{
+                "id": "doc-export-test",
+                "messages": [
+                    {"role": "user", "content": "msg 1"},
+                    {"role": "assistant", "content": "msg 2"},
+                    {"role": "user", "content": "msg 3"}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let source = format!("{}#1-2", input_path.display());
+        let status = super::cmd_export(&source, None, Some(&output_path)).unwrap();
+        assert_eq!(status, std::process::ExitCode::SUCCESS);
+
+        let out_text = std::fs::read_to_string(&output_path).unwrap();
+        let parsed = Simple::from_text(&out_text).unwrap();
+        let common = Simple::to_common(&parsed).unwrap();
+        assert_eq!(common.body.len(), 2);
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -15,10 +15,10 @@
 //! txcript continue <file|->[#range]     # continue a Simple document (file, or stdin
 //!     --with <harness> [...]                #   for `-`) into <harness>; see
 //!                                           #   docs/formats/simple.md
-//! txcript crop <id>[#range]             # interactively cut messages and save a copy
+//! txcript crop <id|file>[#range]         # interactively cut messages and save a copy
 //!     [--with <harness>]                    #   optionally convert the cropped copy
 //!     [--from <harness>]                    #   scope the source lookup
-//! txcript view <id>[#range]             # view a session; compact text when piped
+//! txcript view <id|file|->[#range]       # view a session; compact text when piped
 //!     [--from <harness>]                    #   scope the id lookup to one harness
 //!     [--no-pager]                          #   print the terminal view directly
 //! txcript query '<pattern>'             # one-shot literal search, ranked hits
@@ -1095,6 +1095,29 @@ fn cmd_crop(
         ensure_crop_target(known_target)?;
     }
 
+    if let Some((input, request)) = document_source(source) {
+        if from.is_some() {
+            return Err(
+                "--from scopes the search for a local session; a Simple document is its own input"
+                    .to_string(),
+            );
+        }
+        let target = with.ok_or_else(|| {
+            "a Simple document has no harness of its own to crop into; \
+             pass --with <harness> (e.g. --with claude_code)"
+                .to_string()
+        })?;
+        ensure_crop_target(target)?;
+        if matches!(input, DocInput::Stdin) {
+            return Err(
+                "cannot crop a document from stdin because crop requires interactive terminal input"
+                    .to_string(),
+            );
+        }
+        let common = read_document_input(&input)?;
+        return crop_loaded(&common, HarnessId::Simple, target, request.as_ref());
+    }
+
     if let Some(loaded) = load_direct_claude_chat(source, from) {
         let target = with.unwrap_or(HarnessId::ClaudeChat);
         let (common, request) = loaded?;
@@ -1280,9 +1303,9 @@ fn cmd_continue(
     }
 }
 
-/// What `continue` received when it wasn't a session id: a Simple document
-/// on stdin or in a file.
-enum DocInput {
+/// What `continue`, `view`, `export`, or `crop` received when it wasn't a
+/// session id: a Simple document on stdin or in a file.
+pub(crate) enum DocInput {
     Stdin,
     File(PathBuf),
 }
@@ -1292,7 +1315,7 @@ enum DocInput {
 /// document. A whole argument that names one wins over the range
 /// interpretation, so a filename containing `#` still opens. Everything
 /// else is a session reference for the discovery path.
-fn document_source(input: &str) -> Option<(DocInput, Option<fragment::SpanReq>)> {
+pub(crate) fn document_source(input: &str) -> Option<(DocInput, Option<fragment::SpanReq>)> {
     if input == "-" {
         return Some((DocInput::Stdin, None));
     }
@@ -1316,21 +1339,8 @@ fn readable_document(path: &str) -> bool {
     std::fs::metadata(path).is_ok_and(|m| !m.is_dir())
 }
 
-/// Continue a Simple document into `--with`: parse, convert, write into the
-/// target's store, launch. The document is read once and never modified;
-/// from here on the conversation lives in the target harness.
-fn continue_document(
-    input: &DocInput,
-    span_req: Option<&fragment::SpanReq>,
-    with: Option<HarnessId>,
-    out: Option<&std::path::Path>,
-    resume: bool,
-) -> Result<ExitCode, String> {
-    let target = with.ok_or_else(|| {
-        "a Simple document has no harness of its own to resume; \
-         pass --with <harness> (e.g. --with claude_code)"
-            .to_string()
-    })?;
+/// Read a Simple document input into the canonical Common model.
+pub(crate) fn read_document_input(input: &DocInput) -> Result<Transcript<Common>, String> {
     let text = match input {
         DocInput::Stdin => {
             let mut buffer = String::new();
@@ -1348,7 +1358,25 @@ fn continue_document(
         DocInput::Stdin => None,
         DocInput::File(path) => Some(path.as_path()).filter(|p| p.is_file()),
     };
-    let common = document_to_common(&text, origin)?;
+    document_to_common(&text, origin)
+}
+
+/// Continue a Simple document into `--with`: parse, convert, write into the
+/// target's store, launch. The document is read once and never modified;
+/// from here on the conversation lives in the target harness.
+fn continue_document(
+    input: &DocInput,
+    span_req: Option<&fragment::SpanReq>,
+    with: Option<HarnessId>,
+    out: Option<&std::path::Path>,
+    resume: bool,
+) -> Result<ExitCode, String> {
+    let target = with.ok_or_else(|| {
+        "a Simple document has no harness of its own to resume; \
+         pass --with <harness> (e.g. --with claude_code)"
+            .to_string()
+    })?;
+    let common = read_document_input(input)?;
 
     let mut copy = match span_req {
         Some(req) => fragment::sliced(&common, req)?,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -153,7 +153,7 @@ pub enum SessionCommand {
         /// `#range` of 1-based inclusive message numbers (`abc#5-12`, `#7`,
         /// `#5-`, `#-10`)
         // Other: without a hint, generated completions fall back to filenames.
-        #[arg(value_hint = clap::ValueHint::Other)]
+        #[arg(value_hint = clap::ValueHint::Other, allow_hyphen_values = true)]
         id: String,
         /// Continue in this harness instead of the session's own
         #[arg(long, value_name = "HARNESS", value_parser = HarnessParser)]
@@ -180,9 +180,10 @@ pub enum SessionCommand {
     /// The source is never modified. By default the cropped copy is written
     /// to the source harness; --with converts it to another harness instead.
     Crop {
-        /// Session id (any unambiguous prefix) or exact title, optionally with
-        /// an initial message range (`abc#5-12`, `abc#7`, `abc#5-`, `abc#-10`)
-        #[arg(value_hint = clap::ValueHint::Other)]
+        /// Session id (any unambiguous prefix) or exact title; or a Simple
+        /// document file. Optionally with an initial message range (`abc#5-12`,
+        /// `abc#7`, `abc#5-`, `abc#-10`)
+        #[arg(value_hint = clap::ValueHint::Other, allow_hyphen_values = true)]
         source: String,
         /// Write the cropped copy in this harness instead of the source harness
         #[arg(long, value_name = "HARNESS", value_parser = HarnessParser)]
@@ -202,11 +203,12 @@ pub enum SessionCommand {
     /// number messages so a printed ordinal can be fed straight back as a
     /// `#range`.
     View {
-        /// Session id (any unambiguous prefix) or its exact title, with an
-        /// optional `#range` of 1-based inclusive message numbers
-        /// (`abc#5-12`, `#7`, `#5-`, `#-10`)
+        /// Session id (any unambiguous prefix) or its exact title; or a
+        /// Simple document (a file path, `-` for stdin). Takes an optional
+        /// `#range` of 1-based inclusive message numbers (`abc#5-12`, `#7`,
+        /// `#5-`, `#-10`)
         // Other: without a hint, generated completions fall back to filenames.
-        #[arg(value_hint = clap::ValueHint::Other)]
+        #[arg(value_hint = clap::ValueHint::Other, allow_hyphen_values = true)]
         source: String,
         /// Only look for the session in this harness
         #[arg(long, value_name = "HARNESS", value_parser = HarnessParser)]
@@ -222,10 +224,11 @@ pub enum SessionCommand {
     /// Move it to another machine and `continue <file> --with <harness>`
     /// picks the session up there; a `#range` exports just those messages.
     Export {
-        /// Session id (any unambiguous prefix) or its exact title, with an
-        /// optional `#range` of 1-based inclusive message numbers
-        /// (`abc#5-12`, `#7`, `#5-`, `#-10`)
-        #[arg(value_hint = clap::ValueHint::Other)]
+        /// Session id (any unambiguous prefix) or its exact title; or a
+        /// Simple document (a file path, `-` for stdin). Takes an optional
+        /// `#range` of 1-based inclusive message numbers (`abc#5-12`, `#7`,
+        /// `#5-`, `#-10`)
+        #[arg(value_hint = clap::ValueHint::Other, allow_hyphen_values = true)]
         source: String,
         /// Only look for the session in this harness
         #[arg(long, value_name = "HARNESS", value_parser = HarnessParser)]
@@ -934,6 +937,37 @@ mod identity_tests {
         assert!(matches!(
             cli.command,
             crate::Command::Session(crate::SessionCommand::Continue { ref id, .. }) if id == "session-123"
+        ));
+    }
+
+    #[test]
+    fn hyphen_prefixed_source_arguments_parse_across_commands() {
+        use clap::Parser;
+
+        let cli =
+            crate::Cli::try_parse_from(["txcript", "continue", "-#1", "--with", "codex"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            crate::Command::Session(crate::SessionCommand::Continue { ref id, .. }) if id == "-#1"
+        ));
+
+        let cli = crate::Cli::try_parse_from(["txcript", "view", "-#1"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            crate::Command::Session(crate::SessionCommand::View { ref source, .. }) if source == "-#1"
+        ));
+
+        let cli = crate::Cli::try_parse_from(["txcript", "export", "-#1-5"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            crate::Command::Session(crate::SessionCommand::Export { ref source, .. }) if source == "-#1-5"
+        ));
+
+        let cli = crate::Cli::try_parse_from(["txcript", "crop", "-#1", "--with", "claude_code"])
+            .unwrap();
+        assert!(matches!(
+            cli.command,
+            crate::Command::Session(crate::SessionCommand::Crop { ref source, .. }) if source == "-#1"
         ));
     }
 }

--- a/cli/src/view.rs
+++ b/cli/src/view.rs
@@ -35,6 +35,16 @@ pub fn load_source(
     source: &str,
     from: Option<HarnessId>,
 ) -> Result<(Transcript<Common>, Option<fragment::SpanReq>), String> {
+    if let Some((input, request)) = super::document_source(source) {
+        if from.is_some() {
+            return Err(
+                "--from scopes the search for a local session; a Simple document is its own input"
+                    .to_string(),
+            );
+        }
+        let common = super::read_document_input(&input)?;
+        return Ok((common, request));
+    }
     if let Some(loaded) = super::load_direct_claude_chat(source, from) {
         return loaded;
     }
@@ -1147,5 +1157,43 @@ mod tests {
             std::fs::read_to_string(destination).unwrap(),
             "rendered session\n"
         );
+    }
+
+    #[test]
+    fn load_source_reads_simple_document_file_with_optional_range() {
+        let dir = tempfile::tempdir().unwrap();
+        let doc_path = dir.path().join("transcript.json");
+        std::fs::write(
+            &doc_path,
+            r#"{
+                "id": "my-doc",
+                "messages": [
+                    {"role": "user", "content": "one"},
+                    {"role": "assistant", "content": "two"}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let (transcript, req) = load_source(doc_path.to_str().unwrap(), None).unwrap();
+        assert_eq!(transcript.meta.id, "my-doc");
+        assert_eq!(transcript.body.len(), 2);
+        assert!(req.is_none());
+
+        let ranged = format!("{}#1", doc_path.display());
+        let (transcript, req) = load_source(&ranged, None).unwrap();
+        assert_eq!(transcript.meta.id, "my-doc");
+        assert!(req.is_some());
+    }
+
+    #[test]
+    fn load_source_rejects_from_scoping_on_simple_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let doc_path = dir.path().join("transcript.json");
+        std::fs::write(&doc_path, "{}").unwrap();
+
+        let err =
+            load_source(doc_path.to_str().unwrap(), Some(txcript::HarnessId::Codex)).unwrap_err();
+        assert!(err.contains("--from scopes the search for a local session"));
     }
 }


### PR DESCRIPTION
## Summary

Extends the CLI commands `view`, `export`, and `crop` to accept [Simple](docs/formats/simple.md) interchange documents (via file path or stdin `-`, with optional `#range` fragment expressions) alongside agent session identifiers.

### Motivation & Problem
Previously, only `txcript continue` had support for reading detached Simple documents (`continue <file|->[#range] --with <harness>`) via `document_source`. Users attempting to inspect (`txcript view session.json#1-5`), slice/re-format (`txcript export session.json#1-10 --out sliced.json`), or crop (`txcript crop session.json --with claude_code`) would encounter discovery failures because those commands assumed inputs were exclusively local harness session IDs or exact titles.

### Changes
1. **Shared Document Resolution (`cli/src/lib.rs`)**:
   - Made `DocInput` and `document_source` `pub(crate)`.
   - Extracted `pub(crate) fn read_document_input(input: &DocInput) -> Result<Transcript<Common>, String>` to parse documents from file or stdin into the canonical `Common` transcript.
   - Refactored `continue_document` to use `read_document_input`.
   - Added Simple document handling to `cmd_crop`:
     - Checks whether `source` is a `document_source`.
     - Validates that `--from` is not supplied (Simple documents are their own input).
     - Requires `--with <harness>` (since a standalone Simple document does not carry its own target harness).
     - Validates that stdin `-` is rejected for `crop` because interactive cropping requires raw terminal control.

2. **Unified `view` Loading (`cli/src/view.rs`)**:
   - In `view::load_source`, intercepts `document_source(source)` prior to local session discovery.
   - Parses the document file or stdin into `Transcript<Common>` while honoring any trailing `#range` fragment.
   - Rejects `--from` scoping when the input is a Simple document.
   - Added unit tests:
     - `load_source_reads_simple_document_file_with_optional_range`
     - `load_source_rejects_from_scoping_on_simple_document`

3. **Export Slicing and Verification (`cli/src/export.rs`)**:
   - Slicing and exporting existing documents directly now works end-to-end via `view::load_source`.
   - Updated module documentation to document direct document re-exporting.
   - Added integration test `cmd_export_slices_existing_simple_document`.

4. **Documentation Updates (`README.md`, `cli/src/lib.rs`)**:
   - Updated command synopsis for `crop <id|file>[#range]`, `view <id|file|->[#range]`, and `export <id|file|->[#range]`.
   - Clarified behavior for Simple document inputs across documentation and `--help`.

### Verification
- `cargo fmt --all -- --check` passed cleanly.
- `cargo clippy -p txcript --no-default-features --features opencode,hermes,search --all-targets -- -D warnings` passed with 0 warnings.
- `cargo test -p txcript --no-default-features --features opencode,hermes,search --test integration` passed (162 passed, 0 failed).
