### PR TITLE
fix(store): reject Windows reserved device names, invalid characters, and trailing dots/spaces

### DIFF
--- a/src/harness/amp.rs
+++ b/src/harness/amp.rs
@@ -1058,6 +1058,9 @@ impl Store for AmpStore {
     }
 
     fn save(&self, transcript: &Transcript<Amp>) -> Result<Saved<PathBuf>> {
+        if !transcript.meta.id.is_empty() {
+            super::checked_id_component(Amp::NAME, &transcript.meta.id)?;
+        }
         // The document's own id wins: it is the one `from_common` shaped to
         // Amp's `T-…` rules, and the one the CLI resumes by. A foreign
         // `meta.id` (a Claude uuid) is not a valid Amp thread id.

--- a/src/harness/campfire.rs
+++ b/src/harness/campfire.rs
@@ -79,6 +79,7 @@ impl Store for CampfireStore {
     }
 
     fn save(&self, transcript: &Transcript<Campfire>) -> Result<Saved<PathBuf>> {
+        super::checked_id_component(Campfire::NAME, &transcript.meta.id)?;
         pi::write_session(&self.sessions_dir, &transcript.meta, &transcript.body)
     }
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -76,12 +76,37 @@ where
 /// absolute id replaces it entirely. Only a single, plain component is
 /// accepted — no separators, no `.`/`..`, no drive-style `:`, no control
 /// characters, not empty.
+/// Checks whether `name` matches a Windows reserved device name (CON, PRN, AUX,
+/// NUL, COM1..COM9, LPT1..LPT9), with or without arbitrary file extensions.
+fn is_reserved_device_name(name: &str) -> bool {
+    let stem = name.split('.').next().unwrap_or(name);
+    let stem = stem.trim_end_matches([' ', '.']);
+    if stem.eq_ignore_ascii_case("CON")
+        || stem.eq_ignore_ascii_case("PRN")
+        || stem.eq_ignore_ascii_case("AUX")
+        || stem.eq_ignore_ascii_case("NUL")
+    {
+        return true;
+    }
+    if stem.len() == 4 {
+        let (prefix, digit) = stem.split_at(3);
+        if (prefix.eq_ignore_ascii_case("COM") || prefix.eq_ignore_ascii_case("LPT"))
+            && digit.chars().all(|c| c.is_ascii_digit())
+        {
+            return true;
+        }
+    }
+    false
+}
+
 pub(crate) fn checked_id_component(harness: &'static str, id: &str) -> crate::Result<()> {
     let ok = !id.is_empty()
         && id != "."
         && id != ".."
-        && !id.contains(['/', '\\', ':'])
-        && !id.chars().any(char::is_control);
+        && !id.ends_with(['.', ' '])
+        && !id.contains(['/', '\\', ':', '<', '>', '"', '|', '?', '*'])
+        && !id.chars().any(char::is_control)
+        && !is_reserved_device_name(id);
     if ok {
         Ok(())
     } else {

--- a/src/harness/pi.rs
+++ b/src/harness/pi.rs
@@ -559,7 +559,7 @@ pub(crate) fn write_session(
     let id = meta.id.clone();
     // Callers are the pi and campfire stores; either way the id is the
     // transcript's own.
-    super::checked_id_component("pi", &id)?;
+    super::checked_id_component(Pi::NAME, &id)?;
     let cwd = meta.cwd.as_deref().unwrap_or_default();
     let dir = sessions_dir.join(encode_cwd(cwd));
     fs::create_dir_all(&dir)?;

--- a/src/local.rs
+++ b/src/local.rs
@@ -704,6 +704,13 @@ pub fn write_with(
     }
 
     let root = opts.root;
+    if !common.meta.id.is_empty()
+        && target != HarnessId::ChatGpt
+        && target != HarnessId::ClaudeChat
+        && target != HarnessId::Simple
+    {
+        crate::harness::checked_id_component(target.as_str(), &common.meta.id)?;
+    }
     match target {
         HarnessId::ClaudeCode => write_claude_code(common, root),
         // Live web sources are server-authoritative and have no import. Their

--- a/tests/integration/path_safety.rs
+++ b/tests/integration/path_safety.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use chrono::{TimeZone, Utc};
 use txcript::common::{Block, Message, Meta, Role};
 use txcript::harness::{
-    amp, antigravity, campfire, claude_code, codex, cursor, grok, grok_bot, pi,
+    amp, antigravity, campfire, claude_code, codex, cowork, cursor, fx, grok, grok_bot, pi,
 };
 use txcript::{Codec, Common, Store, Transcript};
 
@@ -88,6 +88,8 @@ fn hostile_ids_cannot_escape_any_file_backed_store() {
         &antigravity::AntigravityStore::new(root.to_path_buf()),
         root,
     );
+    assert_save_confined(&fx::FxStore::new(root.to_path_buf()), root);
+    assert_save_confined(&cowork::CoworkStore::new(root.to_path_buf()), root);
 }
 
 #[test]
@@ -98,6 +100,112 @@ fn traversal_id_is_rejected_before_anything_is_written() {
     let store = claude_code::ClaudeStore::new(dir.path().to_path_buf());
     let native = claude_code::ClaudeCode::from_common(&small_common("../../pwned")).unwrap();
     assert!(store.save(&native).is_err(), "traversal id must not save");
+}
+
+#[test]
+fn windows_reserved_names_and_invalid_components_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let hostile_ids = &[
+        "CON",
+        "con",
+        "aux",
+        "NUL",
+        "COM1",
+        "com2.json",
+        "LPT3",
+        "lpt4.txt",
+        "trailing-dot.",
+        "trailing-space ",
+        "wild*card",
+        "question?mark",
+        "pipe|line",
+        "less<than",
+        "greater>than",
+        "quote\"name",
+    ];
+
+    let claude = claude_code::ClaudeStore::new(root.to_path_buf());
+    let codex = codex::CodexStore::new(root.to_path_buf());
+    let pi = pi::PiStore::new(root.to_path_buf());
+    let campfire = campfire::CampfireStore::new(root.to_path_buf());
+    let cursor = cursor::CursorStore::new(root.to_path_buf());
+    let grok = grok::GrokStore::new(root.to_path_buf());
+    let grok_bot = grok_bot::GrokBotStore::new(root.to_path_buf());
+    let amp = amp::AmpStore::new(root.to_path_buf());
+    let antigravity = antigravity::AntigravityStore::new(root.to_path_buf());
+
+    for &evil in hostile_ids {
+        let common = small_common(evil);
+
+        if let Ok(native) = claude_code::ClaudeCode::from_common(&common) {
+            assert!(claude.save(&native).is_err(), "Claude must refuse `{evil}`");
+        }
+        if let Ok(native) = codex::Codex::from_common(&common) {
+            assert!(codex.save(&native).is_err(), "Codex must refuse `{evil}`");
+        }
+        if let Ok(native) = pi::Pi::from_common(&common) {
+            assert!(pi.save(&native).is_err(), "Pi must refuse `{evil}`");
+        }
+        if let Ok(native) = campfire::Campfire::from_common(&common) {
+            assert!(
+                campfire.save(&native).is_err(),
+                "Campfire must refuse `{evil}`"
+            );
+        }
+        if let Ok(native) = cursor::Cursor::from_common(&common) {
+            assert!(cursor.save(&native).is_err(), "Cursor must refuse `{evil}`");
+        }
+        if let Ok(native) = grok::Grok::from_common(&common) {
+            assert!(grok.save(&native).is_err(), "Grok must refuse `{evil}`");
+        }
+        if let Ok(native) = grok_bot::GrokBot::from_common(&common) {
+            assert!(
+                grok_bot.save(&native).is_err(),
+                "GrokBot must refuse `{evil}`"
+            );
+        }
+        if let Ok(native) = amp::Amp::from_common(&common) {
+            assert!(amp.save(&native).is_err(), "Amp must refuse `{evil}`");
+        }
+        if let Ok(native) = antigravity::Antigravity::from_common(&common) {
+            assert!(
+                antigravity.save(&native).is_err(),
+                "Antigravity must refuse `{evil}`"
+            );
+        }
+        if let Ok(native) = fx::Fx::from_common(&common) {
+            assert!(
+                fx::FxStore::new(root.to_path_buf()).save(&native).is_err(),
+                "Fx must refuse `{evil}`"
+            );
+        }
+        if let Ok(native) = cowork::Cowork::from_common(&common) {
+            assert!(
+                cowork::CoworkStore::new(root.to_path_buf())
+                    .save(&native)
+                    .is_err(),
+                "Cowork must refuse `{evil}`"
+            );
+        }
+    }
+}
+
+#[test]
+fn local_write_rejects_reserved_and_invalid_ids() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    for evil in &["CON", "aux.jsonl", "nul", "COM1", "foo*", "bar?"] {
+        let common = small_common(evil);
+        let opts = txcript::local::WriteOpts {
+            root: Some(root),
+            metadata: None,
+        };
+        assert!(
+            txcript::local::write_with(txcript::HarnessId::Codex, &common, opts).is_err(),
+            "local::write_with must refuse `{evil}`"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Hardens session ID and path component validation across all file-backed stores by rejecting Windows reserved device names (`CON`, `PRN`, `AUX`, `NUL`, `COM1..COM9`, `LPT1..LPT9`), invalid Win32 filename characters (`<`, `>`, `"`, `|`, `?`, `*`), and trailing dots/spaces.

## Problem
`checked_id_component` in `src/harness/mod.rs` previously guarded against empty IDs, `.`, `..`, `/`, `\`, `:`, and control characters, but did not guard against:
1. **Windows Reserved Device Names**: On Windows, opening, creating, or deleting files whose stem is a reserved device name (e.g. `CON`, `PRN`, `AUX`, `NUL`, `COM1`..`COM9`, `LPT1`..`LPT9`, with or without arbitrary file extensions like `con.json` or `aux.jsonl`) accesses MS-DOS hardware device drivers instead of regular files. This causes processes to hang indefinitely waiting for console input, panic, or crash with OS device driver errors.
2. **Win32 Invalid Characters**: Filenames containing `<`, `>`, `"`, `|`, `?`, `*` fail on Windows with OS error 123 ("The filename, directory name, or volume label syntax is incorrect") rather than cleanly returning `crate::Error::Malformed`.
3. **Trailing Dots and Spaces**: Windows Win32 APIs automatically strip trailing dots (`"session."`) and spaces (`"session "`), which can cause unintended file collisions or bypass path containment.
4. **Harness Store Gaps**: `CampfireStore::save` delegated to `pi::write_session` without verifying its own harness ID component, and `local::write_with` did not perform upfront session ID validation across all file-backed stores before initiating disk I/O.

## Solution
1. **`is_reserved_device_name` in `src/harness/mod.rs`**: Inspects the component stem (ignoring trailing dots and spaces) for `CON`, `PRN`, `AUX`, `NUL`, `COM1`..`COM9`, and `LPT1`..`LPT9` (case-insensitively).
2. **`checked_id_component` in `src/harness/mod.rs`**:
   - Rejects reserved device names.
   - Rejects invalid characters: `<`, `>`, `"`, `|`, `?`, `*`.
   - Rejects components ending in `.` or space `' '`.
3. **Store & Dispatch Validation**:
   - Added `super::checked_id_component(Campfire::NAME, &transcript.meta.id)?;` in `CampfireStore::save`.
   - Used `Pi::NAME` instead of literal `"pi"` in `pi::write_session`.
   - Validated `transcript.meta.id` in `AmpStore::save`.
   - Added upfront `crate::harness::checked_id_component(target.as_str(), &common.meta.id)?;` in `local::write_with` for all file-backed stores.
4. **Integration Tests (`tests/integration/path_safety.rs`)**:
   - Added `windows_reserved_names_and_invalid_components_rejected` test verifying that all file-backed stores (`ClaudeStore`, `CodexStore`, `PiStore`, `CampfireStore`, `CursorStore`, `GrokStore`, `GrokBotStore`, `AmpStore`, `AntigravityStore`, `FxStore`, `CoworkStore`) reject reserved device names, invalid characters, and trailing dots/spaces.
   - Added `local_write_rejects_reserved_and_invalid_ids` test verifying upfront rejection in `local::write_with`.

## Verification
- `cargo fmt --all -- --check` (clean)
- `cargo clippy -p txcript --no-default-features --features opencode,hermes,search --all-targets -- -D warnings` (clean, 0 warnings)
- `cargo test -p txcript --no-default-features --features opencode,hermes,search --test integration` (all 188 integration tests pass)
