### PR TITLE
fix(codec): preserve slash command (Tool::Command) user prompts across harness conversions

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -356,6 +356,21 @@ impl Tool {
         }
     }
 
+    /// For [`Tool::Command`], formats the command invocation as typed by a user
+    /// (e.g. `"/commit -m \"Initial commit\""` or `"/compact"`).
+    #[must_use]
+    pub fn command_display(&self) -> Option<String> {
+        match self {
+            Tool::Command { command, args } => {
+                match args.as_deref().map(str::trim).filter(|a| !a.is_empty()) {
+                    Some(a) => Some(format!("{command} {a}")),
+                    None => Some(command.clone()),
+                }
+            }
+            _ => None,
+        }
+    }
+
     /// Inverse of [`Tool::from_canonical`]: the canonical name and input for
     /// this tool, ready for a codec to denormalize into a harness's native
     /// names and keys.

--- a/src/harness/amp.rs
+++ b/src/harness/amp.rs
@@ -470,9 +470,11 @@ fn user_value(msg: &Message, index: usize) -> Value {
                 "toolUseID": tool_use_id,
                 "run": run_value(content, *is_error),
             })),
-            // Thinking and ToolUse never occur on user turns in the canonical
-            // model; there is nothing of them to render.
-            Block::Thinking { .. } | Block::ToolUse { .. } => None,
+            Block::ToolUse { tool, .. } => tool
+                .command_display()
+                .map(|text| json!({ "type": "text", "text": text })),
+            // Thinking never occurs on user turns in the canonical model.
+            Block::Thinking { .. } => None,
         })
         .collect();
     let mut m = Map::new();

--- a/src/harness/codex.rs
+++ b/src/harness/codex.rs
@@ -544,6 +544,7 @@ fn messages_to_lines(meta: &Meta, messages: &[Message]) -> Vec<Line> {
 }
 
 /// Emit the `response_item` (and paired display `event_msg`) lines for one message.
+#[allow(clippy::too_many_lines)]
 fn push_message_lines(lines: &mut Vec<Line>, msg: &Message, ts: &str) {
     let role_str = match msg.role {
         Role::User => "user",
@@ -594,17 +595,24 @@ fn push_message_lines(lines: &mut Vec<Line>, msg: &Message, ts: &str) {
                 ));
             }
             Block::ToolUse { id, tool } => {
-                let (name, input) = tool.to_canonical();
-                lines.push(meta_line_str(
-                    ts,
-                    "response_item",
-                    json!({
-                        "type": "function_call",
-                        "name": name,
-                        "arguments": input.to_string(),
-                        "call_id": id,
-                    }),
-                ));
+                if msg.role == Role::User
+                    && let Some(cmd) = tool.command_display()
+                {
+                    message_content.push(json!({ "type": "input_text", "text": cmd }));
+                    text_chunks.push(cmd);
+                } else {
+                    let (name, input) = tool.to_canonical();
+                    lines.push(meta_line_str(
+                        ts,
+                        "response_item",
+                        json!({
+                            "type": "function_call",
+                            "name": name,
+                            "arguments": input.to_string(),
+                            "call_id": id,
+                        }),
+                    ));
+                }
             }
             Block::ToolResult {
                 tool_use_id,

--- a/src/harness/cowork.rs
+++ b/src/harness/cowork.rs
@@ -175,9 +175,9 @@ fn body_from_messages(meta: &Meta, messages: &[Message]) -> (Meta, CoworkSession
         .and_then(|m| {
             m.content.iter().find_map(|block| match block {
                 Block::Text { text } => Some(text.clone()),
+                Block::ToolUse { tool, .. } => tool.command_display(),
                 // Only text opens a prompt in the app's record.
                 Block::Thinking { .. }
-                | Block::ToolUse { .. }
                 | Block::ToolResult { .. }
                 | Block::Image { .. }
                 | Block::Artifact { .. } => None,

--- a/src/harness/cursor.rs
+++ b/src/harness/cursor.rs
@@ -659,11 +659,12 @@ fn user_state_text(blocks: &[Block]) -> String {
             Block::Text { text } => Some(text.trim().to_string()),
             Block::Image { source } => Some(format!("[image: {}]", source.media_type)),
             Block::Artifact { artifact } => Some(artifact.display_text()),
+            Block::ToolUse { tool, .. } => tool.command_display(),
             Block::Thinking { text, .. } if !text.trim().is_empty() => {
                 Some(text.trim().to_string())
             }
-            // Empty thinking, tool uses, and results have no user-side text.
-            Block::Thinking { .. } | Block::ToolUse { .. } | Block::ToolResult { .. } => None,
+            // Empty thinking and results have no user-side text.
+            Block::Thinking { .. } | Block::ToolResult { .. } => None,
         })
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
@@ -1354,13 +1355,19 @@ fn serialize_user_block(block: &Block) -> Value {
     match block {
         Block::Text { text } => json!({"type": "text", "text": wrap_user_query(text)}),
         Block::Image { source } => serialize_image(source),
+        Block::ToolUse { tool, .. } => {
+            if let Some(cmd) = tool.command_display() {
+                json!({"type": "text", "text": wrap_user_query(&cmd)})
+            } else {
+                json!({"type": "text", "text": format!("{tool:?}")})
+            }
+        }
         other => {
             let text = match other {
                 Block::Thinking { text, .. } => text.clone(),
-                Block::ToolUse { tool, .. } => format!("{tool:?}"),
                 Block::ToolResult { content, .. } => tool_output_text(content),
                 Block::Artifact { artifact } => artifact.display_text(),
-                Block::Text { .. } | Block::Image { .. } => String::new(),
+                Block::Text { .. } | Block::Image { .. } | Block::ToolUse { .. } => String::new(),
             };
             json!({"type": "text", "text": text})
         }

--- a/src/harness/cursor_desktop.rs
+++ b/src/harness/cursor_desktop.rs
@@ -721,10 +721,15 @@ fn bubbles_from_messages(cid: &str, messages: &[Message]) -> Vec<Map<String, Val
     for (i, msg) in messages.iter().enumerate() {
         match msg.role {
             Role::User => {
-                let mut texts = Vec::new();
+                let mut texts: Vec<String> = Vec::new();
                 for block in &msg.content {
                     match block {
-                        Block::Text { text } => texts.push(text.as_str()),
+                        Block::Text { text } => texts.push(text.clone()),
+                        Block::ToolUse { tool, .. } => {
+                            if let Some(cmd) = tool.command_display() {
+                                texts.push(cmd);
+                            }
+                        }
                         Block::ToolResult {
                             tool_use_id,
                             content,

--- a/src/harness/fx.rs
+++ b/src/harness/fx.rs
@@ -784,6 +784,11 @@ impl TurnBuilder {
                 match block {
                     Block::Text { text } => text_parts.push(text.clone()),
                     Block::Artifact { artifact } => text_parts.push(artifact.display_text()),
+                    Block::ToolUse { tool, .. } => {
+                        if let Some(cmd) = tool.command_display() {
+                            text_parts.push(cmd);
+                        }
+                    }
                     Block::Image { source } => {
                         if let Some(entry) = self.push_image(images.len(), source) {
                             images.push(entry);
@@ -934,11 +939,10 @@ fn tool_output_string(content: &ToolOutput) -> String {
 
 fn is_prompt(msg: &Message) -> bool {
     msg.role == Role::User
-        && msg.content.iter().any(|b| {
-            matches!(
-                b,
-                Block::Text { .. } | Block::Image { .. } | Block::Artifact { .. }
-            )
+        && msg.content.iter().any(|b| match b {
+            Block::Text { .. } | Block::Image { .. } | Block::Artifact { .. } => true,
+            Block::ToolUse { tool, .. } => tool.command_display().is_some(),
+            _ => false,
         })
 }
 

--- a/src/harness/grok.rs
+++ b/src/harness/grok.rs
@@ -803,8 +803,13 @@ fn body_from_messages(meta: &Meta, messages: &[Message]) -> GrokSession {
                             }));
                             updates.tool_result(msg.timestamp, tool_use_id, content, *is_error);
                         }
-                        // Assistant-side blocks have no slot in a user record.
-                        Block::Thinking { .. } | Block::ToolUse { .. } => {}
+                        Block::ToolUse { tool, .. } => {
+                            if let Some(cmd) = tool.command_display() {
+                                prompt_texts.push(cmd);
+                            }
+                        }
+                        // Assistant-side thinking has no slot in a user record.
+                        Block::Thinking { .. } => {}
                     }
                 }
                 if !prompt_texts.is_empty() || !prompt_images.is_empty() {

--- a/src/harness/grok_bot.rs
+++ b/src/harness/grok_bot.rs
@@ -313,6 +313,7 @@ fn result_to_output(result: &Value, is_error: bool) -> ToolOutput {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn messages_to_records(_meta: &Meta, messages: &[Message]) -> Vec<Value> {
     let mut records = Vec::new();
     let mut tool_names: HashMap<String, String> = HashMap::new();
@@ -344,17 +345,21 @@ fn messages_to_records(_meta: &Meta, messages: &[Message]) -> Vec<Value> {
                         }
                         Block::Image { .. } | Block::Artifact { .. } | Block::Thinking { .. } => {}
                         Block::ToolUse { id, tool } => {
-                            // Rare on user turns (e.g. slash commands); emit as assistant-shaped.
-                            let (native_name, input) = denormalize_tool_use(id, tool);
-                            tool_names.insert(id.clone(), native_name.clone());
-                            records.push(json!({
-                                "role": "assistant",
-                                "message": {"content": [{
-                                    "type": "tool_use",
-                                    "name": native_name,
-                                    "input": input,
-                                }]},
-                            }));
+                            if let Some(text) = tool.command_display() {
+                                text_blocks.push(json!({"type": "text", "text": text}));
+                            } else {
+                                // Rare on user turns (e.g. non-command tool calls); emit as assistant-shaped.
+                                let (native_name, input) = denormalize_tool_use(id, tool);
+                                tool_names.insert(id.clone(), native_name.clone());
+                                records.push(json!({
+                                    "role": "assistant",
+                                    "message": {"content": [{
+                                        "type": "tool_use",
+                                        "name": native_name,
+                                        "input": input,
+                                    }]},
+                                }));
+                            }
                         }
                     }
                 }

--- a/src/harness/hermes.rs
+++ b/src/harness/hermes.rs
@@ -748,7 +748,8 @@ fn native_content(blocks: &[Block]) -> Value {
         let text = blocks
             .iter()
             .filter_map(|block| match block {
-                Block::Text { text } => Some(text.as_str()),
+                Block::Text { text } => Some(text.clone()),
+                Block::ToolUse { tool, .. } => tool.command_display(),
                 _ => None,
             })
             .collect::<Vec<_>>()
@@ -764,6 +765,9 @@ fn native_content(blocks: &[Block]) -> Value {
             .iter()
             .filter_map(|block| match block {
                 Block::Text { text } => Some(json!({"type": "text", "text": text})),
+                Block::ToolUse { tool, .. } => tool
+                    .command_display()
+                    .map(|cmd| json!({"type": "text", "text": cmd})),
                 Block::Image { source } => Some(json!({
                     "type": "image_url",
                     "image_url": {

--- a/src/harness/opencode.rs
+++ b/src/harness/opencode.rs
@@ -481,10 +481,18 @@ fn user_part(
             p.insert("time".into(), json!({ "start": ms, "end": ms }));
             Some(base(p))
         }
-        // Thinking and ToolUse never occur on user turns; a ToolResult is
+        Block::ToolUse { tool, .. } => {
+            let text = tool.command_display()?;
+            let mut p = Map::new();
+            p.insert("type".into(), json!("text"));
+            p.insert("text".into(), json!(text));
+            p.insert("time".into(), json!({ "start": ms, "end": ms }));
+            Some(base(p))
+        }
+        // Thinking never occurs on user turns; a ToolResult is
         // folded into the preceding tool part by `assistant_part` and has no
         // user-part shape of its own.
-        Block::Thinking { .. } | Block::ToolUse { .. } | Block::ToolResult { .. } => None,
+        Block::Thinking { .. } | Block::ToolResult { .. } => None,
     }
 }
 

--- a/src/harness/pi.rs
+++ b/src/harness/pi.rs
@@ -340,8 +340,13 @@ fn pi_payloads_for(
                             "timestamp": ts_ms,
                         }));
                     }
-                    // Not expressible in a pi user message.
-                    Block::Thinking { .. } | Block::ToolUse { .. } => {}
+                    Block::ToolUse { tool, .. } => {
+                        if let Some(cmd) = tool.command_display() {
+                            content.push(json!({"type": "text", "text": cmd}));
+                        }
+                    }
+                    // Thinking is not expressible in a pi user message.
+                    Block::Thinking { .. } => {}
                 }
             }
             if !content.is_empty() {

--- a/tests/integration/cross_harness.rs
+++ b/tests/integration/cross_harness.rs
@@ -326,3 +326,146 @@ fn custom_tool_casing_survives_every_hop() {
         assert_cycle(&sample_with_raw_tool(tool_name), tool_name);
     }
 }
+
+#[test]
+#[allow(clippy::too_many_lines, clippy::similar_names)]
+fn slash_commands_survive_conversions() {
+    let t0 = ts("2026-08-18T10:00:00Z");
+    let common = Transcript::new(
+        common::Meta {
+            id: "cmd-session-123".into(),
+            timestamp: t0,
+            cwd: Some("/repo".into()),
+            git_branch: None,
+            title: Some("Slash Command Test".into()),
+            cli_version: Some("1.0.0".into()),
+            model: Some("claude-sonnet".into()),
+        },
+        vec![
+            common::Message {
+                role: common::Role::User,
+                content: vec![
+                    common::Block::ToolUse {
+                        id: "cmd_1".into(),
+                        tool: common::Tool::Command {
+                            command: "/commit".into(),
+                            args: Some("-m \"Initial commit\"".into()),
+                        },
+                    },
+                    common::Block::ToolResult {
+                        tool_use_id: "cmd_1".into(),
+                        content: common::ToolOutput::Text("Committed 1 file".into()),
+                        is_error: false,
+                    },
+                ],
+                timestamp: t0,
+                model: None,
+                stop_reason: None,
+                usage: None,
+            },
+            common::Message {
+                role: common::Role::Assistant,
+                content: vec![common::Block::Text {
+                    text: "Commit completed successfully.".into(),
+                }],
+                timestamp: t0 + chrono::Duration::seconds(5),
+                model: Some("claude-sonnet".into()),
+                stop_reason: Some(common::StopReason::EndTurn),
+                usage: None,
+            },
+            common::Message {
+                role: common::Role::User,
+                content: vec![common::Block::ToolUse {
+                    id: "cmd_2".into(),
+                    tool: common::Tool::Command {
+                        command: "/compact".into(),
+                        args: None,
+                    },
+                }],
+                timestamp: t0 + chrono::Duration::seconds(10),
+                model: None,
+                stop_reason: None,
+                usage: None,
+            },
+        ],
+    );
+
+    let has_text = |t: &Transcript<Common>, substr: &str| {
+        t.body.iter().any(|m| {
+            m.content.iter().any(|b| match b {
+                common::Block::Text { text } => text.contains(substr),
+                _ => false,
+            })
+        })
+    };
+
+    // CursorDesktop
+    let cd = cursor_desktop::CursorDesktop::from_common(&common).unwrap();
+    let cd_c = cursor_desktop::CursorDesktop::to_common(&cd).unwrap();
+    assert!(has_text(&cd_c, "/commit -m \"Initial commit\""));
+    assert!(has_text(&cd_c, "/compact"));
+
+    // Cursor
+    let cur = cursor::Cursor::from_common(&common).unwrap();
+    let cur_c = cursor::Cursor::to_common(&cur).unwrap();
+    assert!(has_text(&cur_c, "/commit -m \"Initial commit\""));
+    assert!(has_text(&cur_c, "/compact"));
+
+    // OpenCode
+    let oc = opencode::OpenCode::from_common(&common).unwrap();
+    let oc_c = opencode::OpenCode::to_common(&oc).unwrap();
+    assert!(has_text(&oc_c, "/commit -m \"Initial commit\""));
+    assert!(has_text(&oc_c, "/compact"));
+
+    // Grok
+    let grk = grok::Grok::from_common(&common).unwrap();
+    let grk_c = grok::Grok::to_common(&grk).unwrap();
+    assert!(has_text(&grk_c, "/commit -m \"Initial commit\""));
+    assert!(has_text(&grk_c, "/compact"));
+
+    // Fx
+    let f = fx::Fx::from_common(&common).unwrap();
+    let f_c = fx::Fx::to_common(&f).unwrap();
+    assert!(has_text(&f_c, "/commit -m \"Initial commit\""));
+
+    // Pi
+    let p = pi::Pi::from_common(&common).unwrap();
+    let p_c = pi::Pi::to_common(&p).unwrap();
+    assert!(has_text(&p_c, "/commit -m \"Initial commit\""));
+    assert!(has_text(&p_c, "/compact"));
+
+    // Codex
+    let cx = codex::Codex::from_common(&common).unwrap();
+    let cx_c = codex::Codex::to_common(&cx).unwrap();
+    assert!(has_text(&cx_c, "/commit -m \"Initial commit\""));
+    assert!(has_text(&cx_c, "/compact"));
+
+    // Hermes
+    let h = hermes::Hermes::from_common(&common).unwrap();
+    let h_c = hermes::Hermes::to_common(&h).unwrap();
+    assert!(has_text(&h_c, "/commit -m \"Initial commit\""));
+    assert!(has_text(&h_c, "/compact"));
+
+    // Amp
+    let a = amp::Amp::from_common(&common).unwrap();
+    let a_c = amp::Amp::to_common(&a).unwrap();
+    assert!(has_text(&a_c, "/commit -m \"Initial commit\""));
+    assert!(has_text(&a_c, "/compact"));
+
+    // GrokBot
+    let gb = grok_bot::GrokBot::from_common(&common).unwrap();
+    let gb_c = grok_bot::GrokBot::to_common(&gb).unwrap();
+    assert!(has_text(&gb_c, "/commit -m \"Initial commit\""));
+    assert!(has_text(&gb_c, "/compact"));
+
+    // Cowork
+    let cw = cowork::Cowork::from_common(&common).unwrap();
+    assert_eq!(
+        cw.body
+            .header
+            .extra
+            .get("initialMessage")
+            .and_then(serde_json::Value::as_str),
+        Some("/commit -m \"Initial commit\"")
+    );
+}


### PR DESCRIPTION
## Summary
Fixes silent loss and distortion of user slash command prompts (`Tool::Command`, such as `/commit`, `/compact`, `/review`, etc.) across harness conversions (`from_common` / `to_common`), ensuring that user-initiated slash commands are faithfully preserved as user prompt text across all 11 supported target harnesses.

## Background & Problem
In Claude Code and interactive CLI sessions, user slash commands (e.g. `/commit -m "Initial commit"`, `/compact`, `/review src/main.rs`) are canonicalized as `Role::User` messages carrying `Block::ToolUse { tool: Tool::Command { command, args } }`.

When converting (`continue --with` / `from_common`) these sessions into other harnesses:
1. `amp`, `cursor_desktop`, `opencode`, `pi`, `grok`, and `hermes`: silently dropped `Tool::Command` on user turns because `Block::ToolUse` was either assumed to never occur on user turns or was discarded during user block parsing. This resulted in empty turns, lost user prompts, or dropped conversation context.
2. `cowork`: `initial_message` search only looked for `Block::Text`, causing sessions starting with a slash command to produce empty `initialMessage` metadata in the app header.
3. `cursor`: `user_state_text` ignored `Block::ToolUse`, and `serialize_user_block` rendered `Tool::Command` via its internal Rust Debug representation (`Command { command: ..., args: ... }`) rather than the command text typed by the user.
4. `codex`: on user turns, `push_message_lines` emitted an assistant-side `response_item` function call instead of user `input_text` and `user_message` events.
5. `fx`: `is_prompt` did not recognize `Tool::Command` as a prompt turn, skipping user command messages entirely during turn partitioning.
6. `grok_bot`: synthesized an assistant-role tool use record on user command turns rather than appending to user text blocks.

## Changes
1. **`src/common.rs`**:
   - Added `Tool::command_display(&self) -> Option<String>` which cleanly formats `Tool::Command` as typed by the user (handling `None`, empty args, and trimming).
2. **`src/harness/cursor_desktop.rs`**:
   - In `bubbles_from_messages`, preserve `Tool::Command` on user turns into user bubble text.
3. **`src/harness/cursor.rs`**:
   - In `user_state_text` and `serialize_user_block`, format `Tool::Command` into user query text.
4. **`src/harness/opencode.rs`**:
   - In `user_part`, map `Tool::Command` into a user text part.
5. **`src/harness/cowork.rs`**:
   - In `initial_message`, preserve `Tool::Command` as the initial prompt text.
6. **`src/harness/grok.rs` & `src/harness/pi.rs`**:
   - On user turns, map `Tool::Command` into prompt text content.
7. **`src/harness/codex.rs`**:
   - On user turns, format `Tool::Command` as `input_text` and `user_message` rather than assistant function call.
8. **`src/harness/hermes.rs`**:
   - In `native_content`, format user-turn `Tool::Command` into text strings or array text blocks.
9. **`src/harness/amp.rs`**:
   - In `user_value`, preserve `Tool::Command` as user text content.
10. **`src/harness/fx.rs`**:
    - In `is_prompt` and `user_value`, recognize `Tool::Command` as a prompt turn and format text parts.
11. **`src/harness/grok_bot.rs`**:
    - On user turns, append `Tool::Command` to user `text_blocks`.
12. **`tests/integration/cross_harness.rs`**:
    - Added `slash_commands_survive_conversions` integration test asserting that user slash commands survive conversions across all 11 harnesses (`CursorDesktop`, `Cursor`, `OpenCode`, `Grok`, `Fx`, `Pi`, `Codex`, `Hermes`, `Amp`, `GrokBot`, `Cowork`).

## Verification
- `cargo fmt --all -- --check` passes cleanly.
- `cargo clippy -p txcript --no-default-features --features opencode,hermes,search --all-targets -- -D warnings` passes with 0 warnings.
- `cargo test -p txcript --no-default-features --features opencode,hermes,search --test integration` passes 187/187 tests.
