### PR TITLE
fix(codec): unify StopReason parsing and finish mapping across harnesses

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -124,6 +124,40 @@ pub enum StopReason {
     Other(String),
 }
 
+impl StopReason {
+    /// Parse a stop or finish reason string commonly used by model APIs and harnesses
+    /// (Anthropic, `OpenAI`, `OpenCode`, Pi, Grok, etc.) into a canonical `StopReason`.
+    /// Unrecognized reasons are preserved as `StopReason::Other(s.to_string())`.
+    #[must_use]
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "end_turn" | "stop" => Self::EndTurn,
+            "tool_use" | "tool_calls" | "tool-calls" | "toolUse" => Self::ToolUse,
+            "max_tokens" | "length" => Self::MaxTokens,
+            "stop_sequence" => Self::StopSequence,
+            "aborted" | "cancelled" | "canceled" | "abort" => Self::Aborted,
+            "error" => Self::Error,
+            other => Self::Other(other.to_string()),
+        }
+    }
+
+    /// Canonical representation as an Anthropic-style stop reason string:
+    /// `"end_turn"`, `"tool_use"`, `"max_tokens"`, `"stop_sequence"`, `"aborted"`, `"error"`,
+    /// or the custom reason string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::EndTurn => "end_turn",
+            Self::ToolUse => "tool_use",
+            Self::MaxTokens => "max_tokens",
+            Self::StopSequence => "stop_sequence",
+            Self::Aborted => "aborted",
+            Self::Error => "error",
+            Self::Other(s) => s.as_str(),
+        }
+    }
+}
+
 /// Token accounting for one assistant turn.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Usage {
@@ -573,6 +607,39 @@ mod tests {
         let tool = Tool::from_canonical("Bash", input.clone());
         assert!(matches!(tool, Tool::Bash { .. }));
         assert_eq!(tool.to_canonical().1, input);
+    }
+
+    #[test]
+    fn stop_reason_parsing_and_as_str() {
+        assert_eq!(StopReason::parse("end_turn"), StopReason::EndTurn);
+        assert_eq!(StopReason::parse("stop"), StopReason::EndTurn);
+        assert_eq!(StopReason::parse("tool_use"), StopReason::ToolUse);
+        assert_eq!(StopReason::parse("tool_calls"), StopReason::ToolUse);
+        assert_eq!(StopReason::parse("tool-calls"), StopReason::ToolUse);
+        assert_eq!(StopReason::parse("toolUse"), StopReason::ToolUse);
+        assert_eq!(StopReason::parse("max_tokens"), StopReason::MaxTokens);
+        assert_eq!(StopReason::parse("length"), StopReason::MaxTokens);
+        assert_eq!(StopReason::parse("stop_sequence"), StopReason::StopSequence);
+        assert_eq!(StopReason::parse("aborted"), StopReason::Aborted);
+        assert_eq!(StopReason::parse("cancelled"), StopReason::Aborted);
+        assert_eq!(StopReason::parse("canceled"), StopReason::Aborted);
+        assert_eq!(StopReason::parse("abort"), StopReason::Aborted);
+        assert_eq!(StopReason::parse("error"), StopReason::Error);
+        assert_eq!(
+            StopReason::parse("custom_reason"),
+            StopReason::Other("custom_reason".to_string())
+        );
+
+        assert_eq!(StopReason::EndTurn.as_str(), "end_turn");
+        assert_eq!(StopReason::ToolUse.as_str(), "tool_use");
+        assert_eq!(StopReason::MaxTokens.as_str(), "max_tokens");
+        assert_eq!(StopReason::StopSequence.as_str(), "stop_sequence");
+        assert_eq!(StopReason::Aborted.as_str(), "aborted");
+        assert_eq!(StopReason::Error.as_str(), "error");
+        assert_eq!(
+            StopReason::Other("custom_reason".to_string()).as_str(),
+            "custom_reason"
+        );
     }
 }
 

--- a/src/harness/amp.rs
+++ b/src/harness/amp.rs
@@ -307,14 +307,7 @@ fn parse_state(state: Option<&Value>) -> Option<StopReason> {
 }
 
 fn parse_stop_reason(s: &str) -> StopReason {
-    match s {
-        "end_turn" => StopReason::EndTurn,
-        "tool_use" => StopReason::ToolUse,
-        "max_tokens" => StopReason::MaxTokens,
-        "stop_sequence" => StopReason::StopSequence,
-        "error" => StopReason::Error,
-        other => StopReason::Other(other.to_string()),
-    }
+    StopReason::parse(s)
 }
 
 fn parse_usage(u: &Value) -> Option<Usage> {

--- a/src/harness/antigravity.rs
+++ b/src/harness/antigravity.rs
@@ -706,7 +706,17 @@ fn stop_reason_to_native(reason: &StopReason) -> Option<u64> {
         StopReason::ToolUse => Some(10),
         StopReason::Error => Some(13),
         StopReason::Aborted => Some(16),
-        StopReason::Other(s) => s.strip_prefix("stop-").and_then(|n| n.parse().ok()),
+        StopReason::Other(s) => s
+            .strip_prefix("stop-")
+            .and_then(|n| n.parse().ok())
+            .or_else(|| match StopReason::parse(s) {
+                StopReason::EndTurn | StopReason::StopSequence => Some(2),
+                StopReason::MaxTokens => Some(3),
+                StopReason::ToolUse => Some(10),
+                StopReason::Error => Some(13),
+                StopReason::Aborted => Some(16),
+                StopReason::Other(_) => None,
+            }),
     }
 }
 

--- a/src/harness/chatgpt.rs
+++ b/src/harness/chatgpt.rs
@@ -171,6 +171,14 @@ impl Codec for ChatGpt {
                 model,
                 stop_reason: (role == "assistant").then_some(if has_tool {
                     StopReason::ToolUse
+                } else if let Some(finish) = native
+                    .pointer("/metadata/finish_details/type")
+                    .and_then(Value::as_str)
+                {
+                    match finish {
+                        "interrupted" => StopReason::Aborted,
+                        other => StopReason::parse(other),
+                    }
                 } else if native.get("end_turn").and_then(Value::as_bool) == Some(true) {
                     StopReason::EndTurn
                 } else {

--- a/src/harness/claude_chat.rs
+++ b/src/harness/claude_chat.rs
@@ -819,15 +819,7 @@ fn u64_field(value: &Value, keys: &[&str]) -> Option<u64> {
 }
 
 fn parse_stop_reason(reason: &str) -> StopReason {
-    match reason {
-        "end_turn" | "stop" => StopReason::EndTurn,
-        "tool_use" => StopReason::ToolUse,
-        "max_tokens" | "length" => StopReason::MaxTokens,
-        "stop_sequence" => StopReason::StopSequence,
-        "aborted" | "cancelled" => StopReason::Aborted,
-        "error" => StopReason::Error,
-        other => StopReason::Other(other.to_string()),
-    }
+    StopReason::parse(reason)
 }
 
 fn read_only_error() -> Error {

--- a/src/harness/claude_code.rs
+++ b/src/harness/claude_code.rs
@@ -1146,25 +1146,11 @@ fn serialize_usage(u: &Usage) -> Value {
 
 // Claude's stop_reason strings are the canonical Anthropic set.
 fn parse_stop_reason(s: &str) -> StopReason {
-    match s {
-        "end_turn" => StopReason::EndTurn,
-        "tool_use" => StopReason::ToolUse,
-        "max_tokens" => StopReason::MaxTokens,
-        "stop_sequence" => StopReason::StopSequence,
-        other => StopReason::Other(other.to_string()),
-    }
+    StopReason::parse(s)
 }
 
 fn stop_reason_str(r: &StopReason) -> String {
-    match r {
-        StopReason::EndTurn => "end_turn".into(),
-        StopReason::ToolUse => "tool_use".into(),
-        StopReason::MaxTokens => "max_tokens".into(),
-        StopReason::StopSequence => "stop_sequence".into(),
-        StopReason::Aborted => "aborted".into(),
-        StopReason::Error => "error".into(),
-        StopReason::Other(s) => s.clone(),
-    }
+    r.as_str().to_string()
 }
 
 // ── helpers ────────────────────────────────────────────────────────────

--- a/src/harness/grok.rs
+++ b/src/harness/grok.rs
@@ -653,15 +653,7 @@ fn parse_arguments(arguments: Option<&Value>) -> Value {
 }
 
 fn parse_stop_reason(s: &str) -> StopReason {
-    match s {
-        "end_turn" => StopReason::EndTurn,
-        "tool_use" => StopReason::ToolUse,
-        "max_tokens" => StopReason::MaxTokens,
-        "stop_sequence" => StopReason::StopSequence,
-        "cancelled" => StopReason::Aborted,
-        "error" => StopReason::Error,
-        other => StopReason::Other(other.to_string()),
-    }
+    StopReason::parse(s)
 }
 
 fn stop_reason_str(r: &StopReason) -> String {

--- a/src/harness/hermes.rs
+++ b/src/harness/hermes.rs
@@ -591,15 +591,7 @@ fn value_text(value: &Value) -> String {
 }
 
 fn parse_finish_reason(reason: &str) -> StopReason {
-    match reason {
-        "stop" | "end_turn" => StopReason::EndTurn,
-        "tool_calls" | "tool_use" => StopReason::ToolUse,
-        "length" | "max_tokens" => StopReason::MaxTokens,
-        "stop_sequence" => StopReason::StopSequence,
-        "aborted" | "cancelled" => StopReason::Aborted,
-        "error" => StopReason::Error,
-        other => StopReason::Other(other.to_string()),
-    }
+    StopReason::parse(reason)
 }
 
 fn finish_reason(reason: Option<&StopReason>, has_tools: bool) -> &'static str {

--- a/src/harness/opencode.rs
+++ b/src/harness/opencode.rs
@@ -699,29 +699,17 @@ fn tokens_value(usage: Option<&Usage>) -> Value {
 }
 
 fn parse_finish(s: &str) -> StopReason {
-    match s {
-        "stop" => StopReason::EndTurn,
-        "length" => StopReason::MaxTokens,
-        "tool_use" | "tool-calls" | "tool_calls" => StopReason::ToolUse,
-        "error" => StopReason::Error,
-        other => StopReason::Other(other.to_string()),
-    }
+    StopReason::parse(s)
 }
 
-fn finish_str(r: Option<&StopReason>) -> &'static str {
+fn finish_str(r: Option<&StopReason>) -> &str {
     match r {
         Some(StopReason::MaxTokens) => "length",
         Some(StopReason::ToolUse) => "tool_use",
         Some(StopReason::Error) => "error",
-        // OpenCode requires a finish and has no spelling for these; they all
-        // collapse to "stop".
-        Some(
-            StopReason::EndTurn
-            | StopReason::StopSequence
-            | StopReason::Aborted
-            | StopReason::Other(_),
-        )
-        | None => "stop",
+        Some(StopReason::Aborted) => "abort",
+        Some(StopReason::EndTurn | StopReason::StopSequence) | None => "stop",
+        Some(StopReason::Other(s)) => s.as_str(),
     }
 }
 

--- a/src/harness/pi.rs
+++ b/src/harness/pi.rs
@@ -986,14 +986,7 @@ fn denormalize_tool(tool: &Tool) -> (String, Value) {
 // ── small helpers ──────────────────────────────────────────────────────
 
 fn parse_stop_reason(s: &str) -> StopReason {
-    match s {
-        "stop" => StopReason::EndTurn,
-        "length" => StopReason::MaxTokens,
-        "toolUse" => StopReason::ToolUse,
-        "error" => StopReason::Error,
-        "aborted" => StopReason::Aborted,
-        other => StopReason::Other(other.to_string()),
-    }
+    StopReason::parse(s)
 }
 
 fn stop_reason_str(r: Option<&StopReason>) -> &'static str {

--- a/tests/integration/amp.rs
+++ b/tests/integration/amp.rs
@@ -601,3 +601,26 @@ fn continuing_into_amp_is_refused() {
         );
     }
 }
+
+#[test]
+fn amp_preserves_stop_reasons_roundtrip() {
+    for stop_reason in [
+        common::StopReason::EndTurn,
+        common::StopReason::ToolUse,
+        common::StopReason::MaxTokens,
+        common::StopReason::StopSequence,
+        common::StopReason::Aborted,
+        common::StopReason::Error,
+    ] {
+        let mut common = sample_common();
+        let last_idx = common.body.len() - 1;
+        common.body[last_idx].stop_reason = Some(stop_reason.clone());
+        let native = amp::Amp::from_common(&common).unwrap();
+        let back = amp::Amp::to_common(&native).unwrap();
+        assert_eq!(
+            back.body[last_idx].stop_reason,
+            Some(stop_reason),
+            "Amp roundtrip should preserve stop_reason"
+        );
+    }
+}

--- a/tests/integration/chatgpt.rs
+++ b/tests/integration/chatgpt.rs
@@ -86,3 +86,27 @@ fn friendly_aliases_resolve_to_chatgpt() {
         assert_eq!(alias.parse::<HarnessId>().unwrap(), HarnessId::ChatGpt);
     }
 }
+
+#[test]
+fn chatgpt_finish_details_mapped_to_stop_reason() {
+    let mut fix = fixture();
+    fix["current_node"] = json!("interrupted_assistant");
+    fix["mapping"]["interrupted_assistant"] = json!({
+        "id": "interrupted_assistant",
+        "parent": "user",
+        "children": [],
+        "message": {
+            "id": "m-int",
+            "author": { "role": "assistant" },
+            "create_time": 1_770_000_004,
+            "content": { "content_type": "text", "parts": ["partial text..."] },
+            "metadata": {
+                "finish_details": { "type": "interrupted" }
+            }
+        }
+    });
+    let transcript = chatgpt::ChatGpt::from_text(&fix.to_string()).unwrap();
+    let common = chatgpt::ChatGpt::to_common(&transcript).unwrap();
+    let last = common.body.last().unwrap();
+    assert_eq!(last.stop_reason, Some(txcript::common::StopReason::Aborted));
+}

--- a/tests/integration/claude_code.rs
+++ b/tests/integration/claude_code.rs
@@ -572,3 +572,17 @@ fn commands_are_searchable_by_name() {
         "the command name should be searchable"
     );
 }
+
+#[test]
+fn claude_code_preserves_aborted_and_error_stop_reasons() {
+    let mut common = sample_common();
+    common.body[3].stop_reason = Some(common::StopReason::Aborted);
+    let native = claude_code::ClaudeCode::from_common(&common).unwrap();
+    let back = claude_code::ClaudeCode::to_common(&native).unwrap();
+    assert_eq!(back.body[3].stop_reason, Some(common::StopReason::Aborted));
+
+    common.body[3].stop_reason = Some(common::StopReason::Error);
+    let native = claude_code::ClaudeCode::from_common(&common).unwrap();
+    let back = claude_code::ClaudeCode::to_common(&native).unwrap();
+    assert_eq!(back.body[3].stop_reason, Some(common::StopReason::Error));
+}

--- a/tests/integration/cross_harness.rs
+++ b/tests/integration/cross_harness.rs
@@ -326,3 +326,76 @@ fn custom_tool_casing_survives_every_hop() {
         assert_cycle(&sample_with_raw_tool(tool_name), tool_name);
     }
 }
+
+#[test]
+fn stop_reasons_survive_conversions() {
+    for expected_reason in [
+        common::StopReason::EndTurn,
+        common::StopReason::ToolUse,
+        common::StopReason::MaxTokens,
+        common::StopReason::Aborted,
+        common::StopReason::Error,
+    ] {
+        let mut t = sample();
+        let last_idx = t.body.len() - 1;
+        t.body[last_idx].stop_reason = Some(expected_reason.clone());
+
+        // Roundtrip through Claude Code
+        let claude = claude_code::ClaudeCode::from_common(&t).unwrap();
+        let back_claude = claude_code::ClaudeCode::to_common(&claude).unwrap();
+        assert_eq!(
+            back_claude.body[last_idx].stop_reason,
+            Some(expected_reason.clone()),
+            "ClaudeCode failed for {expected_reason:?}"
+        );
+
+        // Convert Claude Code -> Hermes -> Amp -> Grok -> OpenCode -> Pi -> Antigravity
+        let hermes = convert::<claude_code::ClaudeCode, hermes::Hermes>(&claude).unwrap();
+        let back_hermes = hermes::Hermes::to_common(&hermes).unwrap();
+        assert_eq!(
+            back_hermes.body[last_idx].stop_reason,
+            Some(expected_reason.clone()),
+            "Hermes failed for {expected_reason:?}"
+        );
+
+        let amp = convert::<hermes::Hermes, amp::Amp>(&hermes).unwrap();
+        let back_amp = amp::Amp::to_common(&amp).unwrap();
+        assert_eq!(
+            back_amp.body[last_idx].stop_reason,
+            Some(expected_reason.clone()),
+            "Amp failed for {expected_reason:?}"
+        );
+
+        let grok = convert::<amp::Amp, grok::Grok>(&amp).unwrap();
+        let back_grok = grok::Grok::to_common(&grok).unwrap();
+        assert_eq!(
+            back_grok.body[last_idx].stop_reason,
+            Some(expected_reason.clone()),
+            "Grok failed for {expected_reason:?}"
+        );
+
+        let opencode = convert::<grok::Grok, opencode::OpenCode>(&grok).unwrap();
+        let back_opencode = opencode::OpenCode::to_common(&opencode).unwrap();
+        assert_eq!(
+            back_opencode.body[last_idx].stop_reason,
+            Some(expected_reason.clone()),
+            "OpenCode failed for {expected_reason:?}"
+        );
+
+        let pi = convert::<opencode::OpenCode, pi::Pi>(&opencode).unwrap();
+        let back_pi = pi::Pi::to_common(&pi).unwrap();
+        assert_eq!(
+            back_pi.body[last_idx].stop_reason,
+            Some(expected_reason.clone()),
+            "Pi failed for {expected_reason:?}"
+        );
+
+        let antigravity = convert::<pi::Pi, antigravity::Antigravity>(&pi).unwrap();
+        let back_antigravity = antigravity::Antigravity::to_common(&antigravity).unwrap();
+        assert_eq!(
+            back_antigravity.body[last_idx].stop_reason,
+            Some(expected_reason.clone()),
+            "Antigravity failed for {expected_reason:?}"
+        );
+    }
+}

--- a/tests/integration/grok.rs
+++ b/tests/integration/grok.rs
@@ -679,3 +679,26 @@ fn discovery_ignores_directories_without_session_logs() {
     let store = GrokStore::new(root.path());
     assert!(store.discover().unwrap().is_empty());
 }
+
+#[test]
+fn grok_preserves_stop_reasons_roundtrip() {
+    for stop_reason in [
+        StopReason::EndTurn,
+        StopReason::ToolUse,
+        StopReason::MaxTokens,
+        StopReason::StopSequence,
+        StopReason::Aborted,
+        StopReason::Error,
+    ] {
+        let mut common = representable_common();
+        let last_idx = common.body.len() - 1;
+        common.body[last_idx].stop_reason = Some(stop_reason.clone());
+        let native = Grok::from_common(&common).unwrap();
+        let back = Grok::to_common(&native).unwrap();
+        assert_eq!(
+            back.body[last_idx].stop_reason,
+            Some(stop_reason),
+            "Grok roundtrip should preserve stop_reason"
+        );
+    }
+}

--- a/tests/integration/opencode.rs
+++ b/tests/integration/opencode.rs
@@ -319,3 +319,34 @@ fn custom_and_mcp_tool_names_preserve_exact_casing() {
         }
     }
 }
+
+#[test]
+fn opencode_preserves_stop_reasons_and_abort() {
+    for (stop_reason, expected_finish) in [
+        (common::StopReason::EndTurn, "stop"),
+        (common::StopReason::ToolUse, "tool_use"),
+        (common::StopReason::MaxTokens, "length"),
+        (common::StopReason::Aborted, "abort"),
+        (common::StopReason::Error, "error"),
+    ] {
+        let mut common = sample_common();
+        let last_idx = common.body.len() - 1;
+        common.body[last_idx].stop_reason = Some(stop_reason.clone());
+        let native = opencode::OpenCode::from_common(&common).unwrap();
+        let last_msg = native.body.messages.last().unwrap();
+        assert_eq!(
+            last_msg
+                .info
+                .get("finish")
+                .and_then(serde_json::Value::as_str),
+            Some(expected_finish),
+            "OpenCode finish should match expected_finish for {stop_reason:?}"
+        );
+        let back = opencode::OpenCode::to_common(&native).unwrap();
+        assert_eq!(
+            back.body[last_idx].stop_reason,
+            Some(stop_reason),
+            "OpenCode roundtrip should preserve stop_reason"
+        );
+    }
+}

--- a/tests/integration/pi.rs
+++ b/tests/integration/pi.rs
@@ -345,3 +345,25 @@ fn custom_and_mcp_tool_names_preserve_exact_casing() {
         }
     }
 }
+
+#[test]
+fn pi_preserves_stop_reasons_roundtrip() {
+    for stop_reason in [
+        common::StopReason::EndTurn,
+        common::StopReason::ToolUse,
+        common::StopReason::MaxTokens,
+        common::StopReason::Aborted,
+        common::StopReason::Error,
+    ] {
+        let mut common = sample_common();
+        let last_idx = common.body.len() - 1;
+        common.body[last_idx].stop_reason = Some(stop_reason.clone());
+        let native = pi::Pi::from_common(&common).unwrap();
+        let back = pi::Pi::to_common(&native).unwrap();
+        assert_eq!(
+            back.body[last_idx].stop_reason,
+            Some(stop_reason),
+            "Pi roundtrip should preserve stop_reason"
+        );
+    }
+}


### PR DESCRIPTION
### Summary

Across model providers and harness wire formats, turn completions and stop reasons use different naming conventions (`"end_turn"`, `"stop"`, `"tool_use"`, `"tool_calls"`, `"toolUse"`, `"max_tokens"`, `"length"`, `"stop_sequence"`, `"aborted"`, `"cancelled"`, `"abort"`, `"error"`). Previously, each harness implemented its own narrow parser with inconsistent coverage:

1. **`claude_code`**: Emitted `"aborted"` and `"error"` in `stop_reason_str`, but its `parse_stop_reason` only accepted `end_turn`, `tool_use`, `max_tokens`, `stop_sequence` — degrading `"aborted"` and `"error"` to `StopReason::Other` on roundtrip.
2. **`opencode`**:
   - `parse_finish` only mapped `"stop"`, `"length"`, `"tool_use"`/`"tool_calls"`, `"error"`, failing to parse `"end_turn"`, `"max_tokens"`, `"aborted"`, `"cancelled"`, `"abort"`.
   - `finish_str` grouped `StopReason::Aborted` under `Some(StopReason::EndTurn | ... | StopReason::Aborted) => "stop"`, silently converting cancelled turns into normal completions.
3. **`pi`**: `parse_stop_reason` failed on `"end_turn"`, `"max_tokens"`, `"tool_use"`, `"cancelled"`, falling back to `Other(...)`.
4. **`amp` & `grok`**: Incomplete alias mapping between `"cancelled"`, `"aborted"`, `"stop"`, `"length"`, and `"tool_calls"`.
5. **`chatgpt`**: Missing extraction of `/metadata/finish_details/type` (`"interrupted"` -> `StopReason::Aborted`, `"max_tokens"` -> `StopReason::MaxTokens`).
6. **`antigravity`**: `stop_reason_to_native` did not resolve standard stop aliases in `StopReason::Other`.

### Solution

- **`src/common.rs`**:
  - Added `StopReason::parse(s: &str) -> Self` recognizing all standard finish and stop string aliases across Anthropic, OpenAI, OpenCode, Pi, Grok, etc., while preserving unrecognized strings verbatim as `StopReason::Other(s)`.
  - Added `StopReason::as_str(&self) -> &str` for canonical Anthropic-style string serialization.
  - Added unit test covering all aliases and canonical representations.
- **Unified Harness Codecs**:
  - Replaced ad-hoc stop reason parsers in `claude_code`, `opencode`, `pi`, `amp`, `grok`, `hermes`, and `claude_chat` with `StopReason::parse`.
  - `opencode.rs`: mapped `Some(StopReason::Aborted) => "abort"`, preventing aborted turns from collapsing into normal `"stop"` completions.
  - `chatgpt.rs`: extracted `metadata.finish_details.type` into `StopReason`, correctly mapping `"interrupted"` to `StopReason::Aborted`.
  - `antigravity.rs`: resolved stop aliases in `StopReason::Other` back to native protocol IDs.
- **Integration Tests**:
  - Added `cross_harness::stop_reasons_survive_conversions` testing multi-harness conversion loops (Claude Code -> Hermes -> Amp -> Grok -> OpenCode -> Pi -> Antigravity) for `EndTurn`, `ToolUse`, `MaxTokens`, `Aborted`, and `Error`.
  - Added dedicated stop reason preservation tests in `tests/integration/opencode.rs`, `tests/integration/claude_code.rs`, `tests/integration/pi.rs`, `tests/integration/amp.rs`, `tests/integration/grok.rs`, and `tests/integration/chatgpt.rs`.

### Verification

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p txcript --no-default-features --features opencode,hermes,search --all-targets -- -D warnings`: clean (0 warnings).
- `cargo test -p txcript --no-default-features --features opencode,hermes,search --test integration`: 193 passed, 0 failed.
